### PR TITLE
Update onboard_server_win.md

### DIFF
--- a/azure_arc_servers_jumpstart/docs/onboard_server_win.md
+++ b/azure_arc_servers_jumpstart/docs/onboard_server_win.md
@@ -51,7 +51,7 @@ On the designated machine, Open Powershell ISE **as Administrator** and run the 
 
 ![](../img/onboard_server_win/04.png)
 
-Upon completion, you will have your Linux server, connected as a new Azure Arc resource inside your Resource Group. 
+Upon completion, you will have your Windows server, connected as a new Azure Arc resource inside your Resource Group. 
 
 ![](../img/onboard_server_win/05.png)
 


### PR DESCRIPTION
Correcting typo - page is for onboarding a Windows server. The line edited stated that it was a Linux server that was successfully connected at the end of the process.