### PR TITLE
Updating  helm stable repo url

### DIFF
--- a/azure_arc_k8s_jumpstart/aks/gitops/basic/az_k8sconfig_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks/gitops/basic/az_k8sconfig_aks.sh
@@ -19,7 +19,7 @@ az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --
 kubectl create namespace hello-arc
 
 # Add the official stable repo
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable
 
 # Use Helm to deploy an NGINX ingress controller
 helm install nginx stable/nginx-ingress \


### PR DESCRIPTION
Changing helm repo url from  https://kubernetes-charts.storage.googleapis.com/ to https://charts.helm.sh/stable