### PR TITLE
Fixes for GCP enabled SQL server

### DIFF
--- a/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/variables.tf
+++ b/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/variables.tf
@@ -71,8 +71,9 @@ variable "servicePrincipalTenantId" {
 }
 
 variable "admin_user" {
-  description = "Guest OS Admin Username"
+  description = "Guest OS Admin Username" 
   type        = string
+  default     = "arcdemo" # do not set this to "Administrator"
 }
 
 variable "admin_password" {

--- a/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/variables.tf
+++ b/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/variables.tf
@@ -71,7 +71,7 @@ variable "servicePrincipalTenantId" {
 }
 
 variable "admin_user" {
-  description = "Guest OS Admin Username" 
+  description = "Guest OS Admin Username"
   type        = string
   default     = "arcdemo" # do not set this to "Administrator"
 }


### PR DESCRIPTION
-Updated scenario to specify not to use Administrator username
-Removed "Enable Kubernetes API" because it isn't necessary for this scenario

Fixes #359 
