### PR TITLE
Removed the need to specify kubernetes-version.  Default version will…

### DIFF
--- a/azure_arc_k8s_jumpstart/aks/terraform/main.tf
+++ b/azure_arc_k8s_jumpstart/aks/terraform/main.tf
@@ -9,8 +9,6 @@ resource "azurerm_kubernetes_cluster" "arcdemo" {
   resource_group_name = azurerm_resource_group.arcdemo.name
   dns_prefix          = var.prefix
 
-  kubernetes_version = var.kubernetes_version
-
   default_node_pool {
     name       = "default"
     node_count = var.node_count

--- a/azure_arc_k8s_jumpstart/aks/terraform/variables.tf
+++ b/azure_arc_k8s_jumpstart/aks/terraform/variables.tf
@@ -18,11 +18,6 @@ variable "location" {
   default     = "East US"
 }
 
-variable "kubernetes_version" {
-  description = "Kubernetes version deployed"
-  default     = "1.18.4"
-}
-
 variable "node_count" {
   description = "The number of Azure VMs for this AKS Managed Kubernetes Cluster node pool"
   default     = 1


### PR DESCRIPTION
The default 1.18.4 is not a valid version.  However 1.18.14 is a valid version.  

Better yet, best to just use the current default version.  This can be done by not setting the optional kubernetes_version in the azurerm_kubernetes_cluster provider.  In this way we don't have to maintain the kubernetes_version parameter as older ones go out of support.