### PR TITLE
bug fix scc, cleanup

### DIFF
--- a/arc_data_services/deploy/yaml/arc-data-scc.yaml
+++ b/arc_data_services/deploy/yaml/arc-data-scc.yaml
@@ -1,39 +1,36 @@
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
+apiVersion: v1
+kind: SecurityContextConstraints
 metadata:
-  annotations:
-    kubernetes.io/description: Azure Arc enabled data services custom scc is based on 'nonroot' scc plus additional capabilities.
-  generation: 2
-  name: arc-data-scc
-allowHostDirVolumePlugin: false
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: false
-allowHostPorts: false
-allowPrivilegeEscalation: true
-allowPrivilegedContainer: false
+  name: arc-data-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
 allowedCapabilities:
-  - SETUID
-  - SETGID
-  - CHOWN
-  - SYS_PTRACE
-defaultAddCapabilities: null
+  - SETUID
+    SETGID
+    CHOWN
+    SYS_PTRACE
+defaultAddCapabilities: null
 fsGroup:
-  type: RunAsAny
-readOnlyRootFilesystem: false
+  type: RunAsAny
+readOnlyRootFilesystem: false
 requiredDropCapabilities:
-  - KILL
-  - MKNOD
+  - KILL
+    MKNOD
 runAsUser:
-  type: MustRunAsNonRoot
+  type: MustRunAsNonRoot
 seLinuxContext:
-  type: MustRunAs
+  type: MustRunAsNonRoot
 supplementalGroups:
-  type: RunAsAny
+  type: RunAsAny
 volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - persistentVolumeClaim
-  - projected
-  - secret
+  - configMap
+    downwardAPI
+    emptyDir
+    persistentVolumeClaim
+    projected
+    secret

--- a/arc_data_services/deploy/yaml/bootstrapper.yaml
+++ b/arc_data_services/deploy/yaml/bootstrapper.yaml
@@ -30,10 +30,9 @@ subjects:
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  generation: 1
+  name: bootstrapper
   labels:
     app: bootstrapper
-  name: bootstrapper
 spec:
   replicas: 1
   selector:
@@ -44,22 +43,24 @@ spec:
       labels:
         app: bootstrapper
     spec:
+      serviceAccountName: sa-mssql-controller
+      imagePullSecrets:
+      - name: mssql-private-registry
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
-      - env:
-        - name: ACCEPT_EULA
-          value: "Y"
+      - name: bootstrapper
         image: mcr.microsoft.com/arcdata/arc-bootstrapper:latest
         imagePullPolicy: IfNotPresent
-        name: bootstrapper
-        resources: {}
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
         securityContext:
           runAsUser: 21006
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      serviceAccount: sa-mssql-controller
-      serviceAccountName: sa-mssql-controller
-      terminationGracePeriodSeconds: 30
+        env:
+        - name: ACCEPT_EULA
+          value: "Y"

--- a/arc_data_services/deploy/yaml/postgresql.yaml
+++ b/arc_data_services/deploy/yaml/postgresql.yaml
@@ -3,14 +3,14 @@ data:
   password: <your base64 encoded password>
 kind: Secret
 metadata:
-  name: example-login-secret
+  name: pg1-login-secret
 type: Opaque
 ---
 apiVersion: arcdata.microsoft.com/v1alpha1
 kind: postgresql-12
 metadata:
   generation: 1
-  name: example
+  name: pg1
 spec:
   engine:
     extensions:

--- a/arc_data_services/deploy/yaml/sqlmi.yaml
+++ b/arc_data_services/deploy/yaml/sqlmi.yaml
@@ -4,13 +4,13 @@ data:
   username: <your base64 encoded user name. 'sa' is not allowed>
 kind: Secret
 metadata:
-  name: example-login-secret
+  name: sql1-login-secret
 type: Opaque
 ---
 apiVersion: sql.arcdata.microsoft.com/v1alpha1
 kind: sqlmanagedinstance
 metadata:
-  name: example
+  name: sql1
 spec:
   limits:
     memory: 4Gi
@@ -21,13 +21,7 @@ spec:
   service:
     type: LoadBalancer
   storage:
-    backups:
-      className: default # Use default configured storage class or modify storage class based on your Kubernetes environment
-      size: 5Gi
     data:
-      className: default # Use default configured storage class or modify storage class based on your Kubernetes environment
-      size: 5Gi
-    datalogs:
       className: default # Use default configured storage class or modify storage class based on your Kubernetes environment
       size: 5Gi
     logs:


### PR DESCRIPTION
Something was wrong with the format of the content of arc-data-scc.yaml and it would throw an error when you tried to kubectl apply it to a cluster.

Made unique names for Postgres and SQL examples so that if you create both of them you dont end up with a naming conflict on 'example'.

Removed datalogs and backups from SQL yaml for now because there is a bug with the permissions mounting those volumes right now.  Will add them back in the end-Feb release.