### PR TITLE
Added Subnet Dependency for Client VM NIC

### DIFF
--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/arm_template/dc_vanilla/clientVm.json
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/arm_template/dc_vanilla/clientVm.json
@@ -146,6 +146,7 @@
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Network/networkSecurityGroups/', parameters('networkSecurityGroupName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]",
                 "[resourceId('Microsoft.Network/publicIpAddresses/', variables('publicIpAddressName'))]"
             ],
             "properties": {


### PR DESCRIPTION
Ran into this issue when deploying the clientVM:
![image](https://user-images.githubusercontent.com/46581776/121220709-dc126a80-c852-11eb-98e1-1fb16d699e8b.png)

Since the Subnet isn't explicitly listed as a `dependsOn` dependency for the VM's NIC, in this case - it deployed before the VNET/Subnet, and couldn't find the VNET/Subnet, and threw this error:
![image](https://user-images.githubusercontent.com/46581776/121220974-1c71e880-c853-11eb-81ec-157d61a6c773.png)

This PR adds in the Subnet as a dependency in the ARM Template definition for the NIC - and the deployment succeeds:
![image](https://user-images.githubusercontent.com/46581776/121221107-3dd2d480-c853-11eb-85a5-e35d71013ad9.png)
