### PR TITLE
Fix/#586 kubeconfig overwritten

### DIFF
--- a/azure_arc_k8s_jumpstart/alibaba/terraform/main.tf
+++ b/azure_arc_k8s_jumpstart/alibaba/terraform/main.tf
@@ -10,7 +10,7 @@ module "managed-k8s" {
   worker_instance_types = ["ecs.g6.large"]
   new_sls_project = true
 
-  kube_config_path = "~/.kube/config"
+  kube_config_path = "~/.kube/config_alicloudArc"
 
   cluster_addons = [
    {

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/alibaba/alibaba_terraform/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/alibaba/alibaba_terraform/_index.md
@@ -146,7 +146,7 @@ The only thing you need to do before executing the Terraform plan is to export t
 
   ![Alibaba Cloud Resource Management](./08.png)
 
-* The plan will create the _kubeconfig_ file in the home directory `~/.kube/config_alicloudArc`. You can either use this directly or merge it into your kubeconfig to be used with `kubectl` or `helm`.
+* The plan will create the _kubeconfig_ file in the home directory `~/.kube/config_alicloudArc`. You can either use this directly or merge it into your _kubeconfig_ to be used with `kubectl` or `helm`.
 
    ```shell
    cp ~/.kube/config ~/.kube/config_old


### PR DESCRIPTION
When creating the kubeconfig file with terraform we now don't simply overwrite the default file.
Instead we create a new one called config_alicloudArc.

Additionally we explain how to merge an existing kubeconfig with thenewly generated one and use kubectl config use-context to switch to the newly generated.