### PR TITLE
Alibaba Terraform: update docs to reference tf 1.0 as prerequisite

### DIFF
--- a/docs/azure_arc_jumpstart/azure_arc_k8s/alibaba/alibaba_terraform/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/alibaba/alibaba_terraform/_index.md
@@ -38,7 +38,7 @@ The following README will guide you on how to use the provided [Terraform](https
   aliyun --version
   ```
 
-* [Install Terraform >=0.12](https://learn.hashicorp.com/terraform/getting-started/install.html). Use the below command to check your current installed version.
+* [Install Terraform >=1.0](https://learn.hashicorp.com/terraform/getting-started/install.html). Use the below command to check your current installed version.
 
   ```shell
   terraform -v


### PR DESCRIPTION
The PR #627 raised the tf version to 1.0 but the prerequisits of tf 0.12 was forgotten to be raised as well.

Fix for #636 