### PR TITLE
Update Bootstrap.ps1

### DIFF
--- a/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/Bootstrap.ps1
+++ b/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/Bootstrap.ps1
@@ -80,7 +80,7 @@ Invoke-WebRequest ($templateBaseUrl + "artifacts/wallpaper.png") -OutFile "C:\Te
 # Installing tools
 workflow ClientTools_01
         {
-            $chocolateyAppList = 'azure-cli,az.powershell,kubernetes-cli,vcredist140,microsoft-edge,azcopy10,vscode,putty.install,kubernetes-helm,grep'
+            $chocolateyAppList = 'azure-cli,az.powershell,kubernetes-cli,vcredist140,microsoft-edge,azcopy10,vscode,putty.install,kubernetes-helm,grep,git'
             #Run commands in parallel.
             Parallel 
                 {


### PR DESCRIPTION
Without git installed, the DataServicesLogonScript.ps1 will throw an unexpected error:

Failed to initialize: Bad git executable.
The git executable must be specified in one of the following ways:
- be included in your $PATH
- be set via $GIT_PYTHON_GIT_EXECUTABLE
- explicitly set via git.refresh()