### PR TITLE
Pinned k8s-extension to 0.4.3

### DIFF
--- a/azure_arc_app_services_jumpstart/aks/app_service/arm_template/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/app_service/arm_template/artifacts/AppServicesLogonScript.ps1
@@ -58,7 +58,7 @@ Write-Host "Adding Azure Arc CLI extensions"
 Write-Host "`n"
 az extension add --name "connectedk8s" -y
 az extension add --name "k8s-configuration" -y
-az extension add --name "k8s-extension" -y
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 az extension add --name "customlocation" -y
 az extension add --yes --source "https://aka.ms/appsvc/appservice_kube-latest-py2.py3-none-any.whl"
 

--- a/azure_arc_data_jumpstart/aks/arm_template/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/arm_template/artifacts/DataServicesLogonScript.ps1
@@ -48,7 +48,7 @@ Write-Host "Adding Azure Arc CLI extensions"
 Write-Host "`n"
 az extension add --name "connectedk8s" -y
 az extension add --name "k8s-configuration" -y
-az extension add --name "k8s-extension" -y
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 az extension add --name "customlocation" -y
 
 Write-Host "`n"

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/arm_template/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/arm_template/artifacts/DataServicesLogonScript.ps1
@@ -51,7 +51,7 @@ Write-Host "Adding Azure Arc CLI extensions"
 Write-Host "`n"
 az extension add --name "connectedk8s" -y
 az extension add --name "k8s-configuration" -y
-az extension add --name "k8s-extension" -y
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 az extension add --name "customlocation" -y
 
 Write-Host "`n"

--- a/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
@@ -37,7 +37,7 @@ az provider register --namespace Microsoft.AzureArcData --wait
 Write-Host "Adding Azure Arc CLI extensions"
 az extension add --name "connectedk8s" -y
 az extension add --name "k8s-configuration" -y
-az extension add --name "k8s-extension" -y
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 az extension add --name "customlocation" -y
 Write-Host "`n"
 az -v

--- a/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
@@ -51,7 +51,7 @@ Write-Host "Adding Azure Arc CLI extensions"
 Write-Host "`n"
 az extension add --name "connectedk8s" -y
 az extension add --name "k8s-configuration" -y
-az extension add --name "k8s-extension" -y
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 az extension add --name "customlocation" -y
 
 Write-Host "`n"

--- a/azure_arc_k8s_jumpstart/aks_stack_hci/monitor_extension/azure_monitor_k8s_extension.ps1
+++ b/azure_arc_k8s_jumpstart/aks_stack_hci/monitor_extension/azure_monitor_k8s_extension.ps1
@@ -22,8 +22,7 @@ az extension update --name "connectedk8s"
 
 # Checking if you have up-to-date Azure Arc AZ CLI 'k8s-extension' extension...
 
-az extension add --name "k8s-extension"
-az extension update --name "k8s-extension"
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 
 # Login to Az CLI using the service principal
 az login --service-principal --username $appId --password $password --tenant $tenantId

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_defender_extension/azure_defender_k8s_extension.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_defender_extension/azure_defender_k8s_extension.sh
@@ -45,10 +45,14 @@ echo ""
 echo "Checking if you have up-to-date Azure Arc AZ CLI 'k8s-extension' extension..."
 az extension show --name "k8s-extension" &> extension_output
 if cat extension_output | grep -q "not installed"; then
-az extension add --name "k8s-extension"
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 rm extension_output
 else
-az extension update --name "k8s-extension"
+# az extension update --name "k8s-extension" # Temporary removal of update logic due to above pin - added 2 lines above to fully remove, then update to pin
+##############################################################################
+az extension remove --name "k8s-extension" # Fully remove
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
+##############################################################################
 rm extension_output
 fi
 echo ""

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_osm_extension/capi_osm_extension.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_osm_extension/capi_osm_extension.sh
@@ -51,10 +51,14 @@ echo ""
 echo "Checking if you have up-to-date Azure Arc AZ CLI 'k8s-extension' extension..."
 az extension show --name "k8s-extension" &> extension_output
 if cat extension_output | grep -q "not installed"; then
-az extension add --name "k8s-extension"
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 rm extension_output
 else
-az extension update --name "k8s-extension"
+# az extension update --name "k8s-extension" # Temporary removal of update logic due to above pin - added 2 lines above to fully remove, then update to pin
+##############################################################################
+az extension remove --name "k8s-extension" # Fully remove
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
+##############################################################################
 rm extension_output
 fi
 echo ""

--- a/azure_arc_k8s_jumpstart/gke/gke_monitor_extension/azure_monitor_k8s_extension.sh
+++ b/azure_arc_k8s_jumpstart/gke/gke_monitor_extension/azure_monitor_k8s_extension.sh
@@ -45,10 +45,14 @@ echo ""
 echo "Checking if you have up-to-date Azure Arc AZ CLI 'k8s-extension' extension..."
 az extension show --name "k8s-extension" &> extension_output
 if cat extension_output | grep -q "not installed"; then
-az extension add --name "k8s-extension"
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 rm extension_output
 else
-az extension update --name "k8s-extension"
+# az extension update --name "k8s-extension" # Temporary removal of update logic due to above pin - added 2 lines above to fully remove, then update to pin
+##############################################################################
+az extension remove --name "k8s-extension" # Fully remove
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
+##############################################################################
 rm extension_output
 fi
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/DataServicesLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DataServicesLogonScript.ps1
@@ -37,7 +37,7 @@ az provider register --namespace Microsoft.AzureArcData --wait
 Write-Host "Adding Azure Arc CLI extensions"
 az extension add --name "connectedk8s" -y
 az extension add --name "k8s-configuration" -y
-az extension add --name "k8s-extension" -y
+az extension add --name "k8s-extension" --version "0.4.3" -y # Temporary pin
 az extension add --name "customlocation" -y
 Write-Host "`n"
 az -v


### PR DESCRIPTION
* Pinnded `k8s-extension` to 0.4.3 working version
* Any `update` logic for `k8s-extension` has been changed to `remove` and then `add` to pin (`az extension update` does not support specifying version).

I have tested the end-to-end deployment with the Microk8s Data scenario - here's a screenshot at the very end of the successful deployment:
![image](https://user-images.githubusercontent.com/46581776/125002644-6a7d3600-e023-11eb-925b-4a8af84c06e2.png)


