### PR TITLE
Clarification to the kind gitops documentation.

### DIFF
--- a/docs/azure_arc_jumpstart/azure_arc_k8s/day2/kind/local_kind_gitops_helm/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/day2/kind/local_kind_gitops_helm/_index.md
@@ -91,7 +91,7 @@ The demo application that will be deployed later in this guide relies on an ingr
 
     ![Running ingress nginx controller](./03.png)
 
-> **Note: If the ingress controller fails to start, you should redeploy the kind cluster with [kind_cluster_ingress.yaml](https://github.com/microsoft/azure_arc/blob/main/azure_arc_k8s_jumpstart/kind/kind_cluster_ingress.yaml) instead of kind_cluster.yaml.**
+> **Note: If the ingress controller fails to start, you should redeploy the kind cluster with [_kind_cluster_ingress.yaml_](https://github.com/microsoft/azure_arc/blob/main/azure_arc_k8s_jumpstart/kind/kind_cluster_ingress.yaml) instead of _kind_cluster.yaml_.**
 
 * Finally, test that the ingress is responding to traffic. To test this, either browse to [http://localhost](http://localhost) or use the command line to connect to `localhost`. You should get a HTTP 404 response with a nginx footer. This shows that the ingress is working. The 404 response is to be expected since you haven't setup an ingress route yet. You will do that in the next section.
 

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/day2/kind/local_kind_gitops_helm/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/day2/kind/local_kind_gitops_helm/_index.md
@@ -14,7 +14,7 @@ In this guide, you will first deploy a nginx ingress controller to your cluster.
 
 By doing so, you will be able to make real-time changes to the application and show how the GitOps flow takes effect.
 
-> **Note: This guide assumes you already deployed a kind and connected it to Azure Arc. If you haven't, this repository offers you a way to do so in the [kind onboarding guide](https://azurearcjumpstart.io/azure_arc_jumpstart/azure_arc_k8s/kind/local_kind/).**
+> **Note: This guide assumes you already deployed a kind and connected it to Azure Arc. If you haven't, this repository offers you a way to do so in the [kind onboarding guide](https://azurearcjumpstart.io/azure_arc_jumpstart/azure_arc_k8s/kind/local_kind/). Furthermore, kind should be deployed with [kind_cluster_ingress.yaml](https://github.com/microsoft/azure_arc/blob/main/azure_arc_k8s_jumpstart/kind/kind_cluster_ingress.yaml) instead of kind_cluster.yaml**
 
 ## Prerequisites
 
@@ -90,6 +90,8 @@ The demo application that will be deployed later in this guide relies on an ingr
 * This command will create a new namespace and deploy the required components in this namespace. To verify the deployment of the ingress controller was successful, make sure the pod with name `ingress-nginx-controller-<random id>-<random id>` is in a running state with 1/1 containers ready:
 
     ![Running ingress nginx controller](./03.png)
+
+> **Note: If the ingress controller fails to start, you should redeploy the kind cluster with [kind_cluster_ingress.yaml](https://github.com/microsoft/azure_arc/blob/main/azure_arc_k8s_jumpstart/kind/kind_cluster_ingress.yaml) instead of kind_cluster.yaml.**
 
 * Finally, test that the ingress is responding to traffic. To test this, either browse to [http://localhost](http://localhost) or use the command line to connect to `localhost`. You should get a HTTP 404 response with a nginx footer. This shows that the ingress is working. The 404 response is to be expected since you haven't setup an ingress route yet. You will do that in the next section.
 

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/day2/kind/local_kind_gitops_helm/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/day2/kind/local_kind_gitops_helm/_index.md
@@ -14,7 +14,7 @@ In this guide, you will first deploy a nginx ingress controller to your cluster.
 
 By doing so, you will be able to make real-time changes to the application and show how the GitOps flow takes effect.
 
-> **Note: This guide assumes you already deployed a kind and connected it to Azure Arc. If you haven't, this repository offers you a way to do so in the [kind onboarding guide](https://azurearcjumpstart.io/azure_arc_jumpstart/azure_arc_k8s/kind/local_kind/). Furthermore, kind should be deployed with [kind_cluster_ingress.yaml](https://github.com/microsoft/azure_arc/blob/main/azure_arc_k8s_jumpstart/kind/kind_cluster_ingress.yaml) instead of kind_cluster.yaml**
+> **Note: This guide assumes you already deployed a kind and connected it to Azure Arc. If you haven't, this repository offers you a way to do so in the [kind onboarding guide](https://azurearcjumpstart.io/azure_arc_jumpstart/azure_arc_k8s/kind/local_kind/). Furthermore, kind should be deployed with [_kind_cluster_ingress.yaml_](https://github.com/microsoft/azure_arc/blob/main/azure_arc_k8s_jumpstart/kind/kind_cluster_ingress.yaml) instead of _kind_cluster.yaml_**
 
 ## Prerequisites
 


### PR DESCRIPTION
Added a clarification specifying which .yaml configuration should be used, as the configuration in the initial example will not work for the gitops tutorial.