### PR TITLE
ArcBox - Pin helm version to 3.6 and change loadbalancer ports for SQL MI and PostgreSQL to non-standard (11433 and 15432)

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/DeployPostgreSQL.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DeployPostgreSQL.ps1
@@ -66,6 +66,11 @@ $pgWorkerPodName = "jumpstartpsw0-0"
 
 Start-Sleep -Seconds 60
 
+# Update Service Port from 5432 to Non-Standard
+$payload = '{\"spec\":{\"ports\":[{\"name\":\"port-pgsql\",\"port\":15432,\"targetPort\":5432}]}}'
+kubectl patch svc jumpstartps-external-svc -n arc --type merge --patch $payload
+Sleep 5 # To allow the CRD to update
+
 # Downloading demo database and restoring onto Postgres
 Write-Host "Downloading AdventureWorks.sql template for Postgres... (1/3)"
 kubectl exec $pgControllerPodName -n arc -c postgres -- /bin/bash -c "curl -o /tmp/AdventureWorks2019.sql 'https://jumpstart.blob.core.windows.net/jumpstartbaks/AdventureWorks2019.sql?sp=r&st=2021-09-08T21:04:16Z&se=2030-09-09T05:04:16Z&spr=https&sv=2020-08-04&sr=b&sig=MJHGMyjV5Dh5gqyvfuWRSsCb4IMNfjnkM%2B05F%2F3mBm8%3D'" 2>&1 | Out-Null

--- a/azure_jumpstart_arcbox/artifacts/DeploySQLMI.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DeploySQLMI.ps1
@@ -66,6 +66,11 @@ Do {
 Write-Host "Azure Arc SQL Managed Instance is ready!"
 Write-Host "`n"
 
+# Update Service Port from 1433 to Non-Standard
+$payload = '{\"spec\":{\"ports\":[{\"name\":\"port-mssql-tds\",\"port\":11433,\"targetPort\":1433}]}}'
+kubectl patch svc jumpstart-sql-external-svc -n arc --type merge --patch $payload
+Sleep 5 # To allow the CRD to update
+
 # Downloading demo database and restoring onto SQL MI
 $podname = "jumpstart-sql-0"
 Write-Host "Downloading AdventureWorks database for MS SQL... (1/2)"

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -100,7 +100,7 @@ sudo mv ./clusterctl /usr/local/bin/clusterctl
 clusterctl version
 
 # Installing Helm 3
-sudo snap install helm --channel:3.6/stable --classic # pinning 3.6 due to breaking changes in aak8s onboarding with 3.7
+sudo snap install helm --channel=3.6/stable --classic # pinning 3.6 due to breaking changes in aak8s onboarding with 3.7
 
 echo "Making sure Rancher K3s cluster is ready..."
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -100,7 +100,7 @@ sudo mv ./clusterctl /usr/local/bin/clusterctl
 clusterctl version
 
 # Installing Helm 3
-sudo snap install helm --classic
+sudo snap install helm --channel:3.6/stable --classic # pinning 3.6 due to breaking changes in aak8s onboarding with 3.7
 
 echo "Making sure Rancher K3s cluster is ready..."
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -44,7 +44,7 @@ chown -R $adminUsername /home/${adminUsername}/.kube/
 chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
 # Installing Helm 3
-sudo snap install helm --channel:3.6/stable --classic # pinning 3.6 due to breaking changes in aak8s onboarding with 3.7
+sudo snap install helm --channel=3.6/stable --classic # pinning 3.6 due to breaking changes in aak8s onboarding with 3.7
 
 # Installing Azure CLI & Azure Arc Extensions
 sudo apt-get update

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -44,7 +44,7 @@ chown -R $adminUsername /home/${adminUsername}/.kube/
 chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
 # Installing Helm 3
-sudo snap install helm --classic
+sudo snap install helm --channel:3.6/stable --classic # pinning 3.6 due to breaking changes in aak8s onboarding with 3.7
 
 # Installing Azure CLI & Azure Arc Extensions
 sudo apt-get update

--- a/docs/azure_jumpstart_arcbox/_index.md
+++ b/docs/azure_jumpstart_arcbox/_index.md
@@ -66,7 +66,7 @@ ArcBox uses an advanced automation flow to deploy and configure all necessary re
     * Windows VM - onboarded as Azure Arc-enabled Server
     * Ubuntu VM - onboarded as Azure Arc-enabled Server
     * Windows VM running SQL Server - onboarded as Azure Arc-enabled SQL Server (as well as Azure Arc-enabled Server)
-  * Deploy and configure Azure Arc-enabled data services on the CAPI workload cluster including a data controller, a SQL MI instance, and a PostgreSQL Hyperscale cluster. After deployment, Azure Data Studio opens automatically with connection entries for each database instance. Data services deployed by the script are:
+  * Deploy and configure Azure Arc-enabled data services on the CAPI workload cluster including a data controller, a SQL MI instance, and a PostgreSQL Hyperscale cluster. After deployment, Azure Data Studio opens automatically with connection entries for each database instance. Note that the SQI MI instance and the PostgreSQL Hyperscale instance are exposed by the load balancer on non-standard ports (SQLMI/11433 and PostgreSQL/15432) Data services deployed by the script are:
     * Data controller
     * SQL MI instance
     * Postgres instance


### PR DESCRIPTION
Pin helm version at 3.6 due to a breaking change in 3.7 with data services.

Change SQLMI port from 1433 to 11433
Change PostgreSQL port from 5432 to 15432

Using these nonstandard ports avoids triggering network security policies that block 1433 and 5432.

Addresses #767

Similar to #763 