### PR TITLE
Changed PostgreSQL to non-standard for remaining scenarios

### DIFF
--- a/azure_arc_data_jumpstart/aks/arm_template/artifacts/DeployPostgreSQL.ps1
+++ b/azure_arc_data_jumpstart/aks/arm_template/artifacts/DeployPostgreSQL.ps1
@@ -63,6 +63,12 @@ $pgWorkerPodName = "jumpstartpsw0-0"
         Start-Sleep -Seconds 45
         $buildService = $(if((kubectl get pods -n arc | Select-String $pgCoordinatorPodName| Select-String "Running" -Quiet) -and (kubectl get pods -n arc | Select-String $pgWorkerPodName| Select-String "Running" -Quiet)){"Ready!"}Else{"Nope"})
     } while ($buildService -eq "Nope")
+Write-Host "Azure Arc-enabled PostgreSQL Hyperscale is ready!"
+Write-Host "`n"
+
+# Update Service Port from 5432 to Non-Standard
+$payload = '{\"spec\":{\"ports\":[{\"name\":\"port-pgsql\",\"port\":15432,\"targetPort\":5432}]}}'
+kubectl patch svc jumpstartps-external-svc -n arc --type merge --patch $payload
 
 Start-Sleep -Seconds 60
 


### PR DESCRIPTION
@dkirby-ms as discussed [here](https://github.com/microsoft/azure_arc/issues/763#issuecomment-924308131) - this PR is for Postgres.

Just an FYI - I realized the reason this "works" in Azure (Arcbox, AKS etc.) even though we're doing changes via `kubectl` - is because on Azure, after you flip the `LoadBalancer` `port` - there's an Operator listening in the Cluster somewhere that simultaneously flips the Azure NSG to reflect the K8s state:
![image](https://user-images.githubusercontent.com/46581776/134819513-01eac660-3640-4ffa-8cab-bf8815a8917c.png)

For EKS and GKE, I'm not sure what the behavior will be etc if we perform this sort of change (an initial attempt didn't work for me). My knowledge of Networking there is also limited compared to Azure - so keeping this hardening scoped to Azure for now 😊. 