### PR TITLE
Move description out of the front matter

### DIFF
--- a/docs/azure_arc_jumpstart/azure_arc_servers/day2/arc_managed_identity/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_servers/day2/arc_managed_identity/_index.md
@@ -4,9 +4,12 @@ title: "Managed Identity"
 linkTitle: "Managed Identity"
 weight: 10
 description: >-
-  The scenarios in this section will walk you through how to work with the Hybrid Instance Metadata Service on an Azure Arc-enabled server, and authenticate the system assigned Managed Identity against Azure APIs.
-
-  Using the managed identity opens up custom hybrid integration opportunities beyond the standard integrations such as monitoring, management, backup, and virtual machine extensions.
-
-  The workloads running on your on-premises, hosted, and multi-cloud compute can be onboarded to Azure using an Azure Arc-enabled server and you can then authenticate the managed identity to access Azure services.
 ---
+
+## Using Managed Identity on Azure Arc-enabled servers
+
+The scenarios in this section will walk you through how to work with the Hybrid Instance Metadata Service on an Azure Arc-enabled server, and authenticate the system assigned Managed Identity against Azure APIs.
+
+Using the managed identity opens up custom hybrid integration opportunities beyond the standard integrations such as monitoring, management, backup, and virtual machine extensions.
+
+The workloads running on your on-premises, hosted, and multi-cloud compute can be onboarded to Azure using an Azure Arc-enabled server and you can then authenticate the managed identity to access Azure services.


### PR DESCRIPTION
@likamrat The <https://azurearcjumpstart.io/azure_arc_jumpstart/azure_arc_servers/day2/> page looks odd as none of the day2 pages have descriptions in the front matter.

Reworked!