### PR TITLE
Updating App Services scenarios to remove custom-locations-oid parameter and to set check for active log processor pods from 4 to 3

### DIFF
--- a/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/AppServicesLogonScript.ps1
@@ -74,8 +74,6 @@ az connectedk8s connect --name $env:clusterName `
                         --resource-group $env:resourceGroup `
                         --location $env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_app_services' `
-                        --custom-locations-oid '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
-                        # This is the Custom Locations Enterprise Application ObjectID from AAD
 
 Start-Sleep -Seconds 10
 $kubectlMonShell = Start-Process -PassThru PowerShell {for (0 -lt 1) {kubectl get pod -n appservices; Start-Sleep -Seconds 5; Clear-Host }}

--- a/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/AppServicesLogonScript.ps1
@@ -73,7 +73,7 @@ Write-Host "`n"
 az connectedk8s connect --name $env:clusterName `
                         --resource-group $env:resourceGroup `
                         --location $env:azureLocation `
-                        --tags 'Project=jumpstart_azure_arc_app_services' `
+                        --tags 'Project=jumpstart_azure_arc_app_services'
 
 Start-Sleep -Seconds 10
 $kubectlMonShell = Start-Process -PassThru PowerShell {for (0 -lt 1) {kubectl get pod -n appservices; Start-Sleep -Seconds 5; Clear-Host }}

--- a/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/AppServicesLogonScript.ps1
@@ -124,7 +124,7 @@ Write-Host "Deploying App Service Kubernetes Environment"
 Write-Host "`n"
 $connectedClusterId = az connectedk8s show --name $env:clusterName --resource-group $env:resourceGroup --query id -o tsv
 $extensionId = az k8s-extension show --name $extensionName --cluster-type connectedClusters --cluster-name $env:clusterName --resource-group $env:resourceGroup --query id -o tsv
-$customLocationId = $(az customlocation create --name 'jumpstart-cl' --resource-group $env:resourceGroup --namespace appservices --host-resource-id $connectedClusterId --cluster-extension-ids $extensionId  --query id -o tsv)
+$customLocationId = $(az customlocation create --name 'jumpstart-cl' --resource-group $env:resourceGroup --namespace appservices --host-resource-id $connectedClusterId --cluster-extension-ids $extensionId --kubeconfig "C:\Users\$env:USERNAME\.kube\config" --query id -o tsv)
 az appservice kube create --resource-group $env:resourceGroup --name $kubeEnvironmentName --custom-location $customLocationId --static-ip "$staticIp" --location $env:azureLocation --output none 
 
 Do {

--- a/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/Bootstrap.ps1
+++ b/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/Bootstrap.ps1
@@ -117,7 +117,7 @@ New-Item -path alias:kubectl -value 'C:\ProgramData\chocolatey\lib\kubernetes-cl
 Creating scheduled task for AppServicesLogonScript.ps1
 $Trigger = New-ScheduledTaskTrigger -AtLogOn
 $Action = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument 'C:\Temp\AppServicesLogonScript.ps1'
-# Register-ScheduledTask -TaskName "AppServicesLogonScript" -Trigger $Trigger -User $adminUsername -Action $Action -RunLevel "Highest" -Force
+Register-ScheduledTask -TaskName "AppServicesLogonScript" -Trigger $Trigger -User $adminUsername -Action $Action -RunLevel "Highest" -Force
 
 # Disabling Windows Server Manager Scheduled Task
 Get-ScheduledTask -TaskName ServerManager | Disable-ScheduledTask

--- a/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/Bootstrap.ps1
+++ b/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/Bootstrap.ps1
@@ -117,7 +117,7 @@ New-Item -path alias:kubectl -value 'C:\ProgramData\chocolatey\lib\kubernetes-cl
 Creating scheduled task for AppServicesLogonScript.ps1
 $Trigger = New-ScheduledTaskTrigger -AtLogOn
 $Action = New-ScheduledTaskAction -Execute "PowerShell.exe" -Argument 'C:\Temp\AppServicesLogonScript.ps1'
-Register-ScheduledTask -TaskName "AppServicesLogonScript" -Trigger $Trigger -User $adminUsername -Action $Action -RunLevel "Highest" -Force
+# Register-ScheduledTask -TaskName "AppServicesLogonScript" -Trigger $Trigger -User $adminUsername -Action $Action -RunLevel "Highest" -Force
 
 # Disabling Windows Server Manager Scheduled Task
 Get-ScheduledTask -TaskName ServerManager | Disable-ScheduledTask

--- a/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/deployFunction.ps1
+++ b/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/deployFunction.ps1
@@ -26,7 +26,7 @@ az functionapp create --resource-group $env:resourceGroup --name $functionAppNam
 Do {
     Write-Host "Waiting for log-processor to become available. Hold tight, this might take a few minutes..."
     Start-Sleep -Seconds 45
-    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  4 Running" -Quiet){"Ready!"}Else{"Nope"})
+    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  3 Running" -Quiet){"Ready!"}Else{"Nope"})
     } while ($logProcessorStatus -eq "Nope")
 
 Do {
@@ -38,7 +38,7 @@ Do {
 Do {
    Write-Host "Waiting for log-processor to become available. Hold tight, this might take a few minutes..."
    Start-Sleep -Seconds 45
-   $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  4 Running" -Quiet){"Ready!"}Else{"Nope"})
+   $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  3 Running" -Quiet){"Ready!"}Else{"Nope"})
    } while ($logProcessorStatus -eq "Nope")
 
 # Retrieving the Azure Storage connection string & Registering binding extensions

--- a/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/deployLogicApp.ps1
+++ b/azure_arc_app_services_jumpstart/aks/arm_template/artifacts/deployLogicApp.ps1
@@ -43,7 +43,7 @@ Do {
 Do {
     Write-Host "Waiting for log-processor to become available. Hold tight, this might take a few minutes..."
     Start-Sleep -Seconds 15
-    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  4 Running" -Quiet){"Ready!"}Else{"Nope"})
+    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  3 Running" -Quiet){"Ready!"}Else{"Nope"})
     } while ($logProcessorStatus -eq "Nope")
 
 # Deploy Logic App code

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/arm_template/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/arm_template/artifacts/AppServicesLogonScript.ps1
@@ -84,7 +84,7 @@ kubectl get nodes
 Write-Host "`n"
 Write-Host "Onboarding the cluster as an Azure Arc enabled Kubernetes cluster"
 Write-Host "`n"
-az connectedk8s connect --name $connectedClusterName --resource-group $env:resourceGroup --location $env:azureLocation --tags 'Project=jumpstart_azure_arc_app_services' --custom-locations-oid '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
+az connectedk8s connect --name $connectedClusterName --resource-group $env:resourceGroup --location $env:azureLocation --tags 'Project=jumpstart_azure_arc_app_services'
 
 Start-Sleep -Seconds 10
 $kubectlMonShell = Start-Process -PassThru PowerShell {for (0 -lt 1) {kubectl get pod -n appservices; Start-Sleep -Seconds 5; Clear-Host }}
@@ -158,7 +158,7 @@ Write-Host "Deploying App Service Kubernetes Environment"
 Write-Host "`n"
 $connectedClusterId = az connectedk8s show --name $connectedClusterName --resource-group $env:resourceGroup --query id -o tsv
 $extensionId = az k8s-extension show --name $extensionName --cluster-type connectedClusters --cluster-name $connectedClusterName --resource-group $env:resourceGroup --query id -o tsv
-$customLocationId = $(az customlocation create --name 'jumpstart-cl' --resource-group $env:resourceGroup --namespace appservices --host-resource-id $connectedClusterId --cluster-extension-ids $extensionId  --query id -o tsv)
+$customLocationId = $(az customlocation create --name 'jumpstart-cl' --resource-group $env:resourceGroup --namespace appservices --host-resource-id $connectedClusterId --cluster-extension-ids $extensionId --kubeconfig "C:\Users\$env:USERNAME\.kube\config" --query id -o tsv)
 az appservice kube create --resource-group $env:resourceGroup --name $kubeEnvironmentName --custom-location $customLocationId --static-ip "$staticIp" --location $env:azureLocation --output none
 
 Do {

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/arm_template/artifacts/deployFunction.ps1
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/arm_template/artifacts/deployFunction.ps1
@@ -26,7 +26,7 @@ az functionapp create --resource-group $env:resourceGroup --name $functionAppNam
 Do {
     Write-Host "Waiting for log-processor to become available. Hold tight, this might take a few minutes..."
     Start-Sleep -Seconds 45
-    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  4 Running" -Quiet){"Ready!"}Else{"Nope"})
+    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  3 Running" -Quiet){"Ready!"}Else{"Nope"})
     } while ($logProcessorStatus -eq "Nope")
 
 Do {

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/arm_template/artifacts/deployLogicApp.ps1
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/arm_template/artifacts/deployLogicApp.ps1
@@ -43,7 +43,7 @@ Do {
 Do {
     Write-Host "Waiting for log-processor to become available. Hold tight, this might take a few minutes..."
     Start-Sleep -Seconds 15
-    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  4 Running" -Quiet){"Ready!"}Else{"Nope"})
+    $logProcessorStatus = $(if(kubectl describe daemonset "arc-app-services-k8se-log-processor" -n appservices | Select-String "Pods Status:  3 Running" -Quiet){"Ready!"}Else{"Nope"})
     } while ($logProcessorStatus -eq "Nope")
 
 # Deploy Logic App code


### PR DESCRIPTION
* removing --custom-locations-oid flag from cluster onboarding
* switching check of running log processor pods to look for 3 pods instead of 4

Closes #837 