### PR TITLE
Updated list of necessary Azure resource providers

### DIFF
--- a/docs/azure_jumpstart_arcbox/_index.md
+++ b/docs/azure_jumpstart_arcbox/_index.md
@@ -93,10 +93,12 @@ ArcBox uses an advanced automation flow to deploy and configure all necessary re
 * Register necessary Azure resource providers by running the following commands.
 
   ```shell
+  az provider register --namespace Microsoft.AzureArcData --wait
+  az provider register --namespace Microsoft.ExtendedLocation --wait
+  az provider register --namespace Microsoft.GuestConfiguration --wait
+  az provider register --namespace Microsoft.HybridCompute --wait
   az provider register --namespace Microsoft.Kubernetes --wait
   az provider register --namespace Microsoft.KubernetesConfiguration --wait
-  az provider register --namespace Microsoft.ExtendedLocation --wait
-  az provider register --namespace Microsoft.AzureArcData --wait
   ```
 
 * Create Azure service principal (SP)


### PR DESCRIPTION
Microsoft.GuestConfiguration and Microsoft.HybridCompute were missing from the list.
Alphabetizing the list is optional, but if these providers are not registered the Azure ARC Server part will not work correctly.