### PR TITLE
Idempotent Deploy 

### DIFF
--- a/azure_jumpstart_arcbox/ARM/mgmt/mgmtArtifacts.json
+++ b/azure_jumpstart_arcbox/ARM/mgmt/mgmtArtifacts.json
@@ -55,11 +55,11 @@
       "galleryName": "Updates"
     },
     "ChangeTracking": {
-      "name": "[concat('ChangeTracking', '(', parameters('workspaceName'), ')')]",
+      "name": "[format('ChangeTracking({0})', parameters('workspaceName'))]",
       "galleryName": "ChangeTracking"
     },
     "Security": {
-      "name": "[concat('Security', '(', parameters('workspaceName'), ')')]",
+      "name": "[format('Security({0})', parameters('workspaceName'))]",
       "galleryName": "Security"
     },
     "policyTemplate": "[if(equals(parameters('flavor'),'ITPro'), uri(parameters('templateBaseUrl'), 'ARM/mgmt/policyAzureArcBuiltinsITPro.json'), if(equals(parameters('flavor'),'DevOps'),uri(parameters('templateBaseUrl'),'ARM/mgmt/policyAzureArcBuiltinsDevOps.json'), uri(parameters('templateBaseUrl'), 'ARM/mgmt/policyAzureArcBuiltinsFull.json')))]",
@@ -146,12 +146,12 @@
       "name": "[variables('ChangeTracking').name]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
       ],
       "plan": {
-        "name": "[concat('ChangeTracking', '(', split(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')),'/')[8], ')')]",
+        "name": "[variables('ChangeTracking').name]",
         "promotionCode": "",
-        "product": "[concat('OMSGallery/', variables('ChangeTracking').galleryName)]",
+        "product": "[format('OMSGallery/{0}', variables('ChangeTracking').galleryName)]",
         "publisher": "Microsoft"
       },
       "properties": {
@@ -164,12 +164,12 @@
       "name": "[variables('Security').name]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
+        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
       ],
       "plan": {
-        "name": "[concat('ChangeTracking', '(', split(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')),'/')[8], ')')]",
+        "name": "[variables('Security').name]",
         "promotionCode": "",
-        "product": "[concat('OMSGallery/', variables('Security').galleryName)]",
+        "product": "[format('OMSGallery/{0}', variables('Security').galleryName)]",
         "publisher": "Microsoft"
       },
       "properties": {

--- a/azure_jumpstart_arcbox/bicep/mgmt/mgmtArtifacts.bicep
+++ b/azure_jumpstart_arcbox/bicep/mgmt/mgmtArtifacts.bicep
@@ -106,7 +106,7 @@ resource changeTrackingGallery 'Microsoft.OperationsManagement/solutions@2015-11
     workspaceResourceId: workspace.id
   }
   plan: {
-    name: 'ChangeTracking(${split(workspace.id, '/')[8]})'
+    name: changeTracking.name
     promotionCode: ''
     product: 'OMSGallery/${changeTracking.galleryName}'
     publisher: 'Microsoft'
@@ -120,7 +120,7 @@ resource securityGallery 'Microsoft.OperationsManagement/solutions@2015-11-01-pr
     workspaceResourceId: workspace.id
   }
   plan: {
-    name: 'ChangeTracking(${split(workspace.id, '/')[8]})'
+    name: security.name
     promotionCode: ''
     product: 'OMSGallery/${security.galleryName}'
     publisher: 'Microsoft'


### PR DESCRIPTION
Bicep and Arm,
As user I want to execute the deploy several times.

It was failing because an issue, two Microsoft.OperationsManagement/solutions plans have the same name.
When re-deploying the template, this difference caused validation to fail with a "can't update plan" error.
The fix (workaround?) is to make sure that the "name" of the resource is the same as the "name" of the plan

Similar issue:
https://github.com/Azure/azure-quickstart-templates/issues/3172#issuecomment-429245027