### PR TITLE
Fixing parameter bug on mgmtMonitorWorkbookDevOps.json

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/mgmtMonitorWorkbookDevOps.json
+++ b/azure_jumpstart_arcbox/artifacts/mgmtMonitorWorkbookDevOps.json
@@ -15,7 +15,7 @@
         "description": "The gallery that the workbook will been shown under. Supported values include workbook, tsg, etc. Usually, this is 'workbook'"
       }
     },
-    "workbookSourceId": {
+    "workbookResourceId": {
       "type": "string",
       "defaultValue": "workbookresourceid-stage",
       "metadata": {


### PR DESCRIPTION
mgmtMonitorWorkbook.parameters.json  the parameter name is "workbookResourceId"  

mgmtMonitorWorkbookFull.json and mgmtMonitorWorkbookITPro.json are ok, but mgmtMonitorWorkbookDevOps.json was wrong.

mgmtMonitorWorkbookFull.json and mgmtMonitorWorkbookITPro.json:
```
      "workbookResourceId": {
        "type": "string",
        "defaultValue": "workbookresourceid-stage",
        "metadata": {
          "description": "The id of resource instance to which the workbook will be associated"
        }
      },
```