### PR TITLE
(ArcBox) Tag resources policy

### DIFF
--- a/azure_jumpstart_arcbox/terraform/modules/mgmt/mgmtPolicy/main.tf
+++ b/azure_jumpstart_arcbox/terraform/modules/mgmt/mgmtPolicy/main.tf
@@ -60,7 +60,7 @@ locals {
           id     = "/providers/Microsoft.Authorization/policyDefinitions/4f9dc7db-30c1-420c-b61a-e1d640128d26"
           params = { "tagName": { "value": "project" }, "tagValue": { "value": "jumpstart_arcbox" }}
           role   = "Tag Contributor"
-          flavor = [ "Full", "DevOps" ]
+          flavor = [ "Full", "DevOps", "ITPro"  ]
       }
   ]
 }


### PR DESCRIPTION
(ArcBox) Tag resources policy added on ITPro for terraform in order to be consistent with ARM/Bicep