### PR TITLE
DevOps scripts at LogOn not runing on full flavor.

### DIFF
--- a/.github/workflows/manual-arcBox-execution-with-parameters.yaml
+++ b/.github/workflows/manual-arcBox-execution-with-parameters.yaml
@@ -273,7 +273,7 @@ jobs:
         run: |
           plink -ssh -P 2204 ${{ github.event.inputs.windowsAdminUsername }}@$(az vm show -d -g ${{ github.event.inputs.resourceGroupName }}  -n ArcBox-Client --query publicIps -o tsv)  -pw  '${{secrets.WINDOWS_ADMIN_PASSWORD}}' -batch 'powershell -InputFormat None -F C:\ArcBox\DataServicesLogonScript.ps1'
       - name: Open SSH, execute DevOpsLogonScript
-        if: github.event.inputs.flavor == 'Full' || github.event.inputs.flavor == 'DevOps'
+        if: github.event.inputs.flavor == 'DevOps'
         run: |
           plink -ssh -P 2204 ${{ github.event.inputs.windowsAdminUsername }}@$(az vm show -d -g ${{ github.event.inputs.resourceGroupName }}  -n ArcBox-Client --query publicIps -o tsv)  -pw  '${{secrets.WINDOWS_ADMIN_PASSWORD}}' -batch 'powershell -InputFormat None -F C:\ArcBox\DevOpsLogonScript.ps1'
       - name: Open SSH, execute MonitorWorkbookLogonScript
@@ -310,7 +310,7 @@ jobs:
           path: DataServicesLogonScript.log
       - name: Upload DevOpsLogonScript.log File
         uses: actions/upload-artifact@v3
-        if: (github.event.inputs.flavor == 'Full' || github.event.inputs.flavor == 'DevOps') &&  (success() || failure())
+        if: (github.event.inputs.flavor == 'DevOps') &&  (success() || failure())
         with:
           name: DevOpsLogonScript.log
           path: DevOpsLogonScript.log

--- a/tests/DeployTestParameters.json
+++ b/tests/DeployTestParameters.json
@@ -1,14 +1,14 @@
 {
   "Full": {
-    "initialResourceAmount": 42,
-    "resourcesAfterScriptExecution": 89,
+    "initialResourceAmount": 45,
+    "resourcesAfterScriptExecution": 87,
     "azureArcMachinesExpected": 5,
     "policiesDeploymentExpected": 6,
     "workbooksExpected": 1,
     "deployBastionDifference": 0,
-    "desktopElementsExpected": 8,
+    "desktopElementsExpected": 9,
     "connectedK8sClustersExpected": 2,
-    "keyVaultsExpected": 1,
+    "keyVaultsExpected": 0,
     "azuredatastudioSettingExpected": 1
   },
   "ITPro": {
@@ -17,8 +17,8 @@
     "azureArcMachinesExpected": 5,
     "policiesDeploymentExpected": 5,
     "workbooksExpected": 1,
-    "deployBastionDifference": 2,
-    "desktopElementsExpected": 2,
+    "deployBastionDifference": 1,
+    "desktopElementsExpected": 3,
     "connectedK8sClustersExpected": 0,
     "keyVaultsExpected": 0,
     "azuredatastudioSettingExpected": 0

--- a/tests/FinalValidation.sh
+++ b/tests/FinalValidation.sh
@@ -133,7 +133,7 @@ for val in $(az resource list -g "$ResourceGroup" --query '[].id' -o tsv | grep 
       echo "policyinsights extension not found on: $name"
       validations=false
    fi
-   if [ "$name" = "ArcBox-CAPI-Data" ]; then
+   if [ "$name" = "ArcBox-CAPI-Data" ] && [ "$Flavor" = "DevOps" ]; then
       count=$(az k8s-extension list --cluster-name $name --cluster-type connectedClusters --resource-group "$ResourceGroup" --query '[].extensionType' -o tsv | grep -h 'azurekeyvaultsecretsprovider' -c)
       if [ "$count" = "1" ]; then
          echo "azurekeyvaultsecretsprovider extension on: $name"


### PR DESCRIPTION
I detected a change on Boostrap script 
https://github.com/microsoft/azure_arc/blob/arcbox_devops/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1#L168-L180

DevOps scripts doesn't run on full flavor as before. I did the changes to simulate that on GitHub Action and I have adjust the parameter during deploys and tests against the latest version.