### PR TITLE
Fix TTL for bootstrapper job

### DIFF
--- a/arc_data_services/deploy/yaml/bootstrapper.yaml
+++ b/arc_data_services/deploy/yaml/bootstrapper.yaml
@@ -25,5 +25,5 @@ spec:
       - name: arc-private-registry
       restartPolicy: Never
       serviceAccountName: sa-arcdata-deployer
-      ttlSecondsAfterFinished: 86400 #24 hours
+  ttlSecondsAfterFinished: 86400 #24 hours
   backoffLimit: 0

--- a/arc_data_services/upgrade/yaml/bootstrapper-upgrade-job.yaml
+++ b/arc_data_services/upgrade/yaml/bootstrapper-upgrade-job.yaml
@@ -17,4 +17,5 @@ spec:
         args: ["-image", "mcr.microsoft.com/arcdata/arc-bootstrapper:v1.9.0_2022-07-12", "-policy", "Always", "-chart", "/opt/helm/arcdataservices", "-bootstrap"]
       restartPolicy: Never
       serviceAccountName: sa-arcdata-deployer
+  ttlSecondsAfterFinished: 86400 #24 hours
   backoffLimit: 0


### PR DESCRIPTION
- ttlSecondsAfterFinished should be under spec, see: https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs
- add ttlSecondsAfterFinished for upgrade job as well