### PR TITLE
correlation-id

### DIFF
--- a/azure_arc_app_services_jumpstart/aks/ARM/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/ARM/artifacts/AppServicesLogonScript.ps1
@@ -82,7 +82,8 @@ az connectedk8s connect --name $Env:connectedClusterName `
                         --location $Env:azureLocation `
                         --tags "jumpstart_azure_arc_app_services" `
                         --kube-config $Env:KUBECONFIG `
-                        --kube-context $Env:KUBECONTEXT
+                        --kube-context $Env:KUBECONTEXT `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 $kubectlMonShell = Start-Process -PassThru PowerShell {for (0 -lt 1) {kubectl get pod -n appservices; Start-Sleep -Seconds 5; Clear-Host }}

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -88,11 +88,11 @@ sudo snap install kubectl --classic
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export CLUSTERCTL_VERSION="1.1.5" # Do not change!
+export CLUSTERCTL_VERSION="1.2.0" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.4.0" # Do not change!
-export KUBERNETES_VERSION="1.24.2" # Do not change!
-export AZURE_DISK_CSI_DRIVER_VERSION="1.19.0"
+export KUBERNETES_VERSION="1.24.3" # Do not change!
+export AZURE_DISK_CSI_DRIVER_VERSION="1.21.0"
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"
@@ -235,7 +235,7 @@ sudo -u $adminUsername kubectl config rename-context "$CLUSTER_NAME-admin@$CLUST
 # Onboarding the cluster to Azure Arc
 echo ""
 workspaceResourceId=$(sudo -u $adminUsername az resource show --resource-group $AZURE_RESOURCE_GROUP --name $logAnalyticsWorkspace --resource-type "Microsoft.OperationalInsights/workspaces" --query id -o tsv)
-sudo -u $adminUsername az connectedk8s connect --name $connectedClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_azure_arc_app_services'
+sudo -u $adminUsername az connectedk8s connect --name $connectedClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_azure_arc_app_services' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 # Enabling Microsoft Defender for Containers and Container Insights cluster extensions
 echo ""

--- a/azure_arc_data_jumpstart/aks/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/ARM/artifacts/DataServicesLogonScript.ps1
@@ -92,7 +92,8 @@ az connectedk8s connect --name $connectedClusterName `
                         --location $Env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_data_services' `
                         --kube-config $Env:KUBECONFIG `
-                        --kube-context $Env:KUBECONTEXT
+                        --kube-context $Env:KUBECONTEXT `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 

--- a/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/DataServicesLogonScript.ps1
@@ -111,7 +111,8 @@ Write-Host "`n"
 az connectedk8s connect --name $primaryConnectedClusterName `
                         --resource-group $Env:resourceGroup `
                         --location $Env:azureLocation `
-                        --tags 'Project=jumpstart_azure_arc_data_services'
+                        --tags 'Project=jumpstart_azure_arc_data_services' `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 

--- a/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/DataServicesLogonScript.ps1
@@ -200,7 +200,8 @@ az connectedk8s connect --name $connectedClusterName `
                         --location $Env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_data_services' `
                         --kube-config $Env:KUBECONFIG `
-                        --kube-context $Env:KUBECONTEXT
+                        --kube-context $Env:KUBECONTEXT `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 

--- a/azure_arc_data_jumpstart/aro/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aro/ARM/artifacts/DataServicesLogonScript.ps1
@@ -122,7 +122,8 @@ az connectedk8s connect --name $connectedClusterName `
                         --location $Env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_data_services' `
                         --kube-config $Env:KUBECONFIG `
-                        --kube-context $Env:KUBECONTEXT
+                        --kube-context $Env:KUBECONTEXT `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -70,11 +70,11 @@ sudo snap install kubectl --classic
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export CLUSTERCTL_VERSION="1.1.5" # Do not change!
+export CLUSTERCTL_VERSION="1.2.0" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.4.0" # Do not change!
-export KUBERNETES_VERSION="1.24.2" # Do not change!
-export AZURE_DISK_CSI_DRIVER_VERSION="1.19.0"
+export KUBERNETES_VERSION="1.24.3" # Do not change!
+export AZURE_DISK_CSI_DRIVER_VERSION="1.21.0"
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"
@@ -217,7 +217,7 @@ sudo -u $adminUsername kubectl config rename-context "$CLUSTER_NAME-admin@$CLUST
 # Onboarding the cluster to Azure Arc
 echo ""
 workspaceResourceId=$(sudo -u $adminUsername az resource show --resource-group $AZURE_RESOURCE_GROUP --name $logAnalyticsWorkspace --resource-type "Microsoft.OperationalInsights/workspaces" --query id -o tsv)
-sudo -u $adminUsername az connectedk8s connect --name $arcK8sClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_azure_arc_data_services'
+sudo -u $adminUsername az connectedk8s connect --name $arcK8sClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_azure_arc_data_services' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 # Enabling Microsoft Defender for Containers and Container Insights cluster extensions
 echo ""

--- a/azure_arc_data_jumpstart/eks/terraform/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/eks/terraform/artifacts/DataServicesLogonScript.ps1
@@ -100,7 +100,8 @@ az connectedk8s connect --name $connectedClusterName `
                         --location $Env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_data_services' `
                         --kube-config $Env:KUBECONFIG `
-                        --kube-context $Env:KUBECONTEXT
+                        --kube-context $Env:KUBECONTEXT `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 

--- a/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
@@ -100,7 +100,8 @@ az connectedk8s connect --name $connectedClusterName `
                         --location $env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_data_services' `
                         --kube-config $env:KUBECONFIG `
-                        --kube-context $env:KUBECONTEXT
+                        --kube-context $env:KUBECONTEXT `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 

--- a/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
@@ -99,7 +99,8 @@ az connectedk8s connect --name $connectedClusterName `
                         --location $env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_data_services' `
                         --kube-config $env:KUBECONFIG `
-                        --kube-context $env:KUBECONTEXT
+                        --kube-context $env:KUBECONTEXT `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 Start-Sleep -Seconds 10
 

--- a/azure_arc_k8s_jumpstart/aks/arm_template/scripts/az_connect_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks/arm_template/scripts/az_connect_aks.sh
@@ -54,4 +54,4 @@ fi
 echo ""
 
 echo "Connecting the cluster to Azure Arc"
-az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --location 'eastus' --tags 'Project=jumpstart_azure_arc_k8s'
+az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --location 'eastus' --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_k8s_jumpstart/aks/terraform/scripts/az_connect_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks/terraform/scripts/az_connect_aks.sh
@@ -54,4 +54,4 @@ fi
 echo ""
 
 echo "Connecting the cluster to Azure Arc"
-az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --location 'eastus' --tags 'Project=jumpstart_azure_arc_k8s'
+az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --location 'eastus' --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/scripts/helm/az_k8sconfig_helm_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/scripts/helm/az_k8sconfig_helm_aks.sh
@@ -12,7 +12,7 @@ export arcClusterName='<The name of your k8s cluster as it will be shown in Azur
 echo "Log in to Azure with Service Principal & Getting AKS credentials (kubeconfig)"
 az login --service-principal --username $appId --password $password --tenant $tenantId
 az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --overwrite-existing
-az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup
+az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 echo "Create Namespace iotedge"
 kubectl create ns iotedge

--- a/azure_arc_k8s_jumpstart/aro/arm_template/scripts/az_connect_aro.sh
+++ b/azure_arc_k8s_jumpstart/aro/arm_template/scripts/az_connect_aro.sh
@@ -81,5 +81,5 @@ user="kube:admin"
 context="default/$clusterName$user"
 
 echo "Connecting the cluster to Azure Arc"
-az connectedk8s connect --name $AZURE_ARC_CLUSTER_RESOURCE_NAME --resource-group $AZURE_RESOURCE_GROUP --location 'eastus' --tags 'Project=jumpstart_azure_arc_k8s' --kube-context $context
+az connectedk8s connect --name $AZURE_ARC_CLUSTER_RESOURCE_NAME --resource-group $AZURE_RESOURCE_GROUP --location 'eastus' --tags 'Project=jumpstart_azure_arc_k8s' --kube-context $context --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 echo ""

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
@@ -15,11 +15,11 @@ echo ""
   export templateBaseUrl="https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_arc_k8s_jumpstart/cluster_api/capi_azure/" # Do not change!
 
   # Set deployment environment variables
-  export CLUSTERCTL_VERSION="1.1.5" # Do not change!
+  export CLUSTERCTL_VERSION="1.2.0" # Do not change!
   export CAPI_PROVIDER="azure" # Do not change!
   export CAPI_PROVIDER_VERSION="1.4.0" # Do not change!
-  export KUBERNETES_VERSION="1.24.2" # Do not change!
-  export AZURE_DISK_CSI_DRIVER_VERSION="1.19.0"
+  export KUBERNETES_VERSION="1.24.3" # Do not change!
+  export AZURE_DISK_CSI_DRIVER_VERSION="1.21.0"
   export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
   export CONTROL_PLANE_MACHINE_COUNT="<Control Plane node count>"
   export WORKER_MACHINE_COUNT="<Workers node count>"
@@ -306,7 +306,7 @@ EOF
   echo ""
 
   echo ""
-  az connectedk8s connect --name $AZURE_ARC_CLUSTER_RESOURCE_NAME --resource-group $AZURE_RESOURCE_GROUP --location $AZURE_LOCATION --kube-config $CLUSTER_NAME.kubeconfig
+  az connectedk8s connect --name $AZURE_ARC_CLUSTER_RESOURCE_NAME --resource-group $AZURE_RESOURCE_GROUP --location $AZURE_LOCATION --kube-config $CLUSTER_NAME.kubeconfig --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   echo ""
 
   # Deploying The Azure disk Container Storage Interface (CSI) Kubernetes driver

--- a/azure_arc_k8s_jumpstart/gke/terraform/scripts/az_connect_gke.sh
+++ b/azure_arc_k8s_jumpstart/gke/terraform/scripts/az_connect_gke.sh
@@ -58,4 +58,4 @@ az provider show -n Microsoft.KubernetesConfiguration -o table
 az provider show -n Microsoft.ExtendedLocation -o table
 
 echo "Connecting the cluster to Azure Arc"
-az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --location $location --tags 'Project=jumpstart_azure_arc_k8s'
+az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --location $location --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_k8s_jumpstart/pf9/pf9_az_connect_k8s.sh
+++ b/azure_arc_k8s_jumpstart/pf9/pf9_az_connect_k8s.sh
@@ -29,4 +29,4 @@ echo "Log in to Azure using service principal"
 az login --service-principal --username $appId --password $password --tenant $tenantId
 
 echo "Connecting the cluster to Azure Arc"
-az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup
+az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/install_k3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/install_k3s.sh
@@ -49,7 +49,7 @@ sudo -u $adminUsername az login --service-principal --username $appId --password
 
 # Onboard the cluster to Azure Arc and enabling Container Insights using Kubernetes extension
 resourceGroup=$(sudo -u $adminUsername az resource list --query "[?name=='$vmName']".[resourceGroup] --resource-type "Microsoft.Compute/virtualMachines" -o tsv)
-sudo -u $adminUsername az connectedk8s connect --name $vmName --resource-group $resourceGroup --location $location --kube-config /home/${adminUsername}/.kube/config --tags 'Project=jumpstart_azure_arc_k8s'
+sudo -u $adminUsername az connectedk8s connect --name $vmName --resource-group $resourceGroup --location $location --kube-config /home/${adminUsername}/.kube/config --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 sudo -u $adminUsername az k8s-extension create -n "azuremonitor-containers" --cluster-name $vmName --resource-group $resourceGroup --cluster-type connectedClusters --extension-type Microsoft.AzureMonitor.Containers
 
 sudo service sshd restart

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/install_k3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/install_k3s.sh
@@ -42,5 +42,5 @@ sudo rm az.sh
 
 # Onboard the cluster to Azure Arc
 resourceGroup=$(az resource list --query "[?name=='$vmName']".[resourceGroup] --resource-type "Microsoft.Compute/virtualMachines" -o tsv)
-az connectedk8s connect --name $vmName --resource-group $resourceGroup --location $location --tags 'Project=jumpstart_azure_arc_k8s'
+az connectedk8s connect --name $vmName --resource-group $resourceGroup --location $location --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 az k8s-extension create -n "azuremonitor-containers" --cluster-name $vmName --resource-group $resourceGroup --cluster-type connectedClusters --extension-type Microsoft.AzureMonitor.Containers

--- a/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/az_connect_k3s.sh.tmpl
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/az_connect_k3s.sh.tmpl
@@ -33,4 +33,4 @@ sudo chmod -R 777 /home/$TF_VAR_admin_user/.azure/config
 sudo chmod -R 777 /home/$TF_VAR_admin_user/.azure
 
 sudo az login --service-principal --username $TF_VAR_client_id --password $TF_VAR_client_secret --tenant $TF_VAR_tenant_id
-sudo az connectedk8s connect --name $TF_VAR_arcClusterName --resource-group $TF_VAR_resourceGroup --location $TF_VAR_location --tags 'Project=jumpstart_azure_arc_k8s'
+sudo az connectedk8s connect --name $TF_VAR_arcClusterName --resource-group $TF_VAR_resourceGroup --location $TF_VAR_location --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_k8s_jumpstart/scripts/az_connect_k8s.sh
+++ b/azure_arc_k8s_jumpstart/scripts/az_connect_k8s.sh
@@ -39,4 +39,4 @@ sudo chmod +x az.sh
 sudo rm az.sh
 
 echo "Connecting the cluster to Azure Arc"
-az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup
+az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_ml_jumpstart/aks/arm_template/artifacts/AzureMLLogonScript.ps1
+++ b/azure_arc_ml_jumpstart/aks/arm_template/artifacts/AzureMLLogonScript.ps1
@@ -92,6 +92,7 @@ az connectedk8s connect --name $connectedClusterName `
                         --resource-group $env:resourceGroup `
                         --location $env:azureLocation `
                         --tags 'Project=jumpstart_azure_arc_ml_services' `
+                        --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a" `
 						      --custom-locations-oid '51dfe1e8-70c6-4de5-a08e-e18aff23d815'
                         # This is the Custom Locations Enterprise Application ObjectID from AAD
 

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -223,7 +223,7 @@ sudo -u $adminUsername kubectl config rename-context "$CLUSTER_NAME-admin@$CLUST
 # Onboarding the cluster to Azure Arc
 echo ""
 workspaceResourceId=$(sudo -u $adminUsername az resource show --resource-group $AZURE_RESOURCE_GROUP --name $logAnalyticsWorkspace --resource-type "Microsoft.OperationalInsights/workspaces" --query id -o tsv)
-sudo -u $adminUsername az connectedk8s connect --name $capiArcDataClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_arcbox'
+sudo -u $adminUsername az connectedk8s connect --name $capiArcDataClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_arcbox' --correlation-id "6038cc5b-b814-4d20-bcaa-0f60392416d5"
 
 # Enabling Microsoft Defender for Containers and Container Insights cluster extensions
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -75,7 +75,7 @@ sudo snap install kustomize
 export CLUSTERCTL_VERSION="1.2.0" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.4.0" # Do not change!
-export KUBERNETES_VERSION="1.24.2" # Do not change!
+export KUBERNETES_VERSION="1.24.3" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.21.0"
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -72,11 +72,11 @@ sudo snap install kubectl --classic
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export CLUSTERCTL_VERSION="1.1.5" # Do not change!
+export CLUSTERCTL_VERSION="1.2.0" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.4.0" # Do not change!
 export KUBERNETES_VERSION="1.24.2" # Do not change!
-export AZURE_DISK_CSI_DRIVER_VERSION="1.19.0"
+export AZURE_DISK_CSI_DRIVER_VERSION="1.21.0"
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/alibaba/alibaba_terraform/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/alibaba/alibaba_terraform/_index.md
@@ -189,7 +189,7 @@ The only thing you need to do before executing the Terraform plan is to export t
   connect the cluster:
 
   ```shell
-  az connectedk8s connect --name $AZURE_CLUSTER_NAME --resource-group $AZURE_RESOURCE_GROUP --location $AZURE_LOCATION
+  az connectedk8s connect --name $AZURE_CLUSTER_NAME --resource-group $AZURE_RESOURCE_GROUP --location $AZURE_LOCATION --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   ```
 
   ![Connect Alibaba cluster to Azure Arc](./09.png)

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/eks/eks_terraform/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/eks/eks_terraform/_index.md
@@ -204,7 +204,7 @@ Now that you have a running EKS cluster, lets connect the EKS cluster to Azure A
 * Deploy Arc binaries using Azure CLI:
 
   ```shell
-  az connectedk8s connect --name "Arc-EKS-Demo" --resource-group "Arc-EKS-Demo" --location "eastus" --tags "Project=jumpstart_azure_arc_k8s"
+  az connectedk8s connect --name "Arc-EKS-Demo" --resource-group "Arc-EKS-Demo" --location "eastus" --tags "Project=jumpstart_azure_arc_k8s" --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   ```
 
 * Upon completion, you will have your EKS cluster connect as a new Azure Arc-enabled Kubernetes resource in a new resource group.

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/general/onboard_k8s/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/general/onboard_k8s/_index.md
@@ -159,13 +159,13 @@ The following Jumpstart scenario will guide you on how to connect an existing Ku
   If using shell:
 
   ```shell
-  az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup
+  az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   ```
 
   If using PowerShell:
 
   ```powershell
-  az connectedk8s connect --name $env:arcClusterName --resource-group $env:resourceGroup
+  az connectedk8s connect --name $env:arcClusterName --resource-group $env:resourceGroup --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   ```
 
 Upon completion, you will have your Kubernetes cluster, connected as a new Azure Arc-enabled Kubernetes resource inside your resource group.

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/kind/local_kind/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/kind/local_kind/_index.md
@@ -170,7 +170,7 @@ The following Jumpstart scenario will guide you on how to use [kind](https://kin
 * Deploy the Arc binaries using Azure CLI:
 
   ```shell
-  az connectedk8s connect -n Arc-kind-Demo -g Arc-kind-Demo --tags 'Project=jumpstart_azure_arc_k8s'
+  az connectedk8s connect -n Arc-kind-Demo -g Arc-kind-Demo --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   ```
 
 * Upon completion, you will have your kind cluster connected as a new Azure Arc Kubernetes cluster resource in a new resource group.

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/microk8s/local_microk8s/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/microk8s/local_microk8s/_index.md
@@ -179,13 +179,13 @@ The following Jumpstart scenario will guide you on how to use [MicroK8s](https:/
   Windows:
 
   ```shell
-  az connectedk8s connect --name Arc-MicroK8s-Demo --resource-group Arc-MicroK8s-Demo --kube-config %HOMEPATH%\.kube\microk8s --kube-context microk8s --tags 'Project=jumpstart_azure_arc_k8s'
+  az connectedk8s connect --name Arc-MicroK8s-Demo --resource-group Arc-MicroK8s-Demo --kube-config %HOMEPATH%\.kube\microk8s --kube-context microk8s --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   ```
 
   Linux and MacOS:
 
   ```shell
-  az connectedk8s connect --name Arc-MicroK8s-Demo --resource-group Arc-MicroK8s-Demo  --kube-config ~/.kube/microk8s --kube-context microk8s --tags 'Project=jumpstart_azure_arc_k8s'
+  az connectedk8s connect --name Arc-MicroK8s-Demo --resource-group Arc-MicroK8s-Demo  --kube-config ~/.kube/microk8s --kube-context microk8s --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
   ```
 
   ![New Azure Arc-enabled Kubernetes cluster](./05.png)

--- a/docs/azure_arc_jumpstart/azure_arc_k8s/rancher_k3s/azure_terraform/_index.md
+++ b/docs/azure_arc_jumpstart/azure_arc_k8s/rancher_k3s/azure_terraform/_index.md
@@ -118,13 +118,13 @@ The only thing you need to do before executing the Terraform plan is to create t
 - Using the Azure service principal you've created, run the below command to connect the cluster to Azure Arc.
 
     ```shell
-    az connectedk8s connect --name <Name of your cluster as it will be shown in Azure> --resource-group <Azure resource group name>
+    az connectedk8s connect --name <Name of your cluster as it will be shown in Azure> --resource-group <Azure resource group name> --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
     ```
 
     For example:
 
     ```shell
-    az connectedk8s connect --name arck3sdemo --resource-group Arc-K3s-Demo
+    az connectedk8s connect --name arck3sdemo --resource-group Arc-K3s-Demo --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
     ```
 
     ![Successful azconnctedk8s command](./05.png)


### PR DESCRIPTION
This PR focuses on adding the _correlation-id_ flag for every _az connectedk8s connect_ command across the repo. 

- Two id's were provided for tracking
  - "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a" - Used for tracking every onboarded K8s cluster as part of a Jumpstart scenario
  - "6038cc5b-b814-4d20-bcaa-0f60392416d5" - Used for tracking every ArcBox deployment. This flag applies only to CAPI clusters to avoid false dup deployments that could have been caused by applying the flag to the K3s cluster as well.

Additional updates for this PR include the following versions bump:

- _CLUSTERCTL_VERSION="1.1.5"_ --> 1.2.0
- _KUBERNETES_VERSION="1.24.2"_ --> 1.24.3
- _AZURE_DISK_CSI_DRIVER_VERSION="1.19.0"_ --> 1.21.0