### PR TITLE
Minimum Version Check for Az.ConnectedMachine

### DIFF
--- a/azure_arc_sqlsrv_jumpstart/azure/arm_template/scripts/installArcAgentSQL.ps1
+++ b/azure_arc_sqlsrv_jumpstart/azure/arm_template/scripts/installArcAgentSQL.ps1
@@ -216,20 +216,20 @@ else
     Write-Verbose "Az already installed. Skipping installation."
 }
 
-if (-Not (Get-InstalledModule -Name Az.ConnectedMachine  -ErrorAction SilentlyContinue)) {
+if (-Not (Get-InstalledModule -Name Az.ConnectedMachine -MinimumVersion 0.4.0 -ErrorAction SilentlyContinue)) {
     Write-Host "Installing Az.connectedMachine module."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Find-Module -Name Az.ConnectedMachine | Install-Module  -Force
+    Find-Module -Name Az.ConnectedMachine | Install-Module -Force
 }
 else
 {
     Write-Verbose "Az.ConnectedMachine already installed. Skipping installation."
 }
 
-if (-Not (Get-InstalledModule -Name Az.Resources  -ErrorAction SilentlyContinue)) {
+if (-Not (Get-InstalledModule -Name Az.Resources -ErrorAction SilentlyContinue)) {
     Write-Host "Installing Az.Resources module."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Find-Module -Name Az.Resources | Install-Module  -Force
+    Find-Module -Name Az.Resources | Install-Module -Force
 }
 else
 {
@@ -239,7 +239,7 @@ else
 # For manual Azure Arc registration, an access token prevents a duplicate Azure login
 # Getting an access token is only supported in Az.Accounts 2.2 or up
 #
-if (-Not (Get-InstalledModule -Name Az.Accounts -MinimumVersion 2.2  -ErrorAction SilentlyContinue) -and -Not $unattended) {
+if (-Not (Get-InstalledModule -Name Az.Accounts -MinimumVersion 2.2 -ErrorAction SilentlyContinue) -and -Not $unattended) {
     Write-Warning "For the best user experience, we recommend updating the Az.Accounts module. Please confirm installation."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Install-Module -Name Az.Accounts -MinimumVersion 2.2 -Confirm -Force

--- a/azure_jumpstart_arcbox/artifacts/installArcAgentSQLSP.ps1
+++ b/azure_jumpstart_arcbox/artifacts/installArcAgentSQLSP.ps1
@@ -216,20 +216,20 @@ else
     Write-Verbose "Az already installed. Skipping installation."
 }
 
-if (-Not (Get-InstalledModule -Name Az.ConnectedMachine  -ErrorAction SilentlyContinue)) {
+if (-Not (Get-InstalledModule -Name Az.ConnectedMachine -MinimumVersion 0.4.0 -ErrorAction SilentlyContinue)) {
     Write-Host "Installing Az.connectedMachine module."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Find-Module -Name Az.ConnectedMachine | Install-Module  -Force
+    Find-Module -Name Az.ConnectedMachine | Install-Module -Force
 }
 else
 {
     Write-Verbose "Az.ConnectedMachine already installed. Skipping installation."
 }
 
-if (-Not (Get-InstalledModule -Name Az.Resources  -ErrorAction SilentlyContinue)) {
+if (-Not (Get-InstalledModule -Name Az.Resources -ErrorAction SilentlyContinue)) {
     Write-Host "Installing Az.Resources module."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Find-Module -Name Az.Resources | Install-Module  -Force
+    Find-Module -Name Az.Resources | Install-Module -Force
 }
 else
 {
@@ -239,7 +239,7 @@ else
 # For manual Azure Arc registration, an access token prevents a duplicate Azure login
 # Getting an access token is only supported in Az.Accounts 2.2 or up
 #
-if (-Not (Get-InstalledModule -Name Az.Accounts -MinimumVersion 2.2  -ErrorAction SilentlyContinue) -and -Not $unattended) {
+if (-Not (Get-InstalledModule -Name Az.Accounts -MinimumVersion 2.2 -ErrorAction SilentlyContinue) -and -Not $unattended) {
     Write-Warning "For the best user experience, we recommend updating the Az.Accounts module. Please confirm installation."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Install-Module -Name Az.Accounts -MinimumVersion 2.2 -Confirm -Force

--- a/azure_jumpstart_arcbox/artifacts/installArcAgentSQLUser.ps1
+++ b/azure_jumpstart_arcbox/artifacts/installArcAgentSQLUser.ps1
@@ -74,20 +74,20 @@ else
 }
 
 
-if (-Not (Get-InstalledModule -Name Az.ConnectedMachine  -ErrorAction SilentlyContinue)) {
+if (-Not (Get-InstalledModule -Name Az.ConnectedMachine -MinimumVersion 0.4.0 -ErrorAction SilentlyContinue)) {
     Write-Host "Installing Az.connectedMachine module."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Find-Module -Name Az.ConnectedMachine | Install-Module  -Force
+    Find-Module -Name Az.ConnectedMachine | Install-Module -Force
 }
 else
 {
     Write-Verbose "Az.ConnectedMachine already installed. Skipping installation."
 }
 
-if (-Not (Get-InstalledModule -Name Az.Resources  -ErrorAction SilentlyContinue)) {
+if (-Not (Get-InstalledModule -Name Az.Resources -ErrorAction SilentlyContinue)) {
     Write-Host "Installing Az.Resources module."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Find-Module -Name Az.Resources | Install-Module  -Force
+    Find-Module -Name Az.Resources | Install-Module -Force
 }
 else
 {
@@ -97,7 +97,7 @@ else
 # For manual Azure Arc registration, an access token prevents a duplicate Azure login
 # Getting an access token is only supported in Az.Accounts 2.2 or up
 #
-if (-Not (Get-InstalledModule -Name Az.Accounts -MinimumVersion 2.2  -ErrorAction SilentlyContinue) -and -Not $unattended) {
+if (-Not (Get-InstalledModule -Name Az.Accounts -MinimumVersion 2.2 -ErrorAction SilentlyContinue) -and -Not $unattended) {
     Write-Warning "For the best user experience, we recommend updating the Az.Accounts module. Please confirm installation."
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Install-Module -Name Az.Accounts -MinimumVersion 2.2 -Confirm -Force


### PR DESCRIPTION
-Added check for version 0.4.0 or higher for Az.ConnectedMachine to avoid older versions failing due to Settings being in HashTable format