### PR TITLE
Fixed Spelling in Parameters File

### DIFF
--- a/azure_arc_sqlsrv_jumpstart/azure/arm_template/azuredeploy.parameters.json
+++ b/azure_arc_sqlsrv_jumpstart/azure/arm_template/azuredeploy.parameters.json
@@ -17,7 +17,7 @@
     "myIpAddress": {
       "value": "<your IP address>"
     },
-    "logAnalayticsWorkspaceName": {
+    "logAnalyticsWorkspaceName": {
       "value": "<your unique Log Analytics workspace name>"
     },
     "servicePrincipalAppId": {


### PR DESCRIPTION
Updated parameters file to correct spelling of logAnalyticsWorkspaceName for Azure Arc-enabled SQL server scenario.