### PR TITLE
k3s version pindown

### DIFF
--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -121,7 +121,7 @@ echo ""
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sLS https://get.k3sup.dev | sh
-sudo k3sup install --local --context arcappcapimgmt --k3s-extra-args '--no-deploy traefik'
+sudo k3sup install --local --context arcappcapimgmt --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo cp kubeconfig ~/.kube/config
 sudo cp kubeconfig /home/${adminUsername}/.kube/config

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -103,7 +103,7 @@ echo ""
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sLS https://get.k3sup.dev | sh
-sudo k3sup install --local --context arcdatacapimgmt --k3s-extra-args '--no-deploy traefik'
+sudo k3sup install --local --context arcdatacapimgmt --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo cp kubeconfig ~/.kube/config
 sudo cp kubeconfig /home/${adminUsername}/.kube/config

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
@@ -178,7 +178,7 @@ echo ""
   sudo mkdir $HOME/.kube
   sudo curl -sLS https://get.k3sup.dev | sh
   sudo cp k3sup /usr/local/bin/k3sup
-  sudo k3sup install --local --context capimgmt --k3s-extra-args '--no-deploy traefik'
+  sudo k3sup install --local --context capimgmt --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
   sudo chmod 644 /etc/rancher/k3s/k3s.yaml
   sudo cp kubeconfig $HOME/.kube/config
   sudo cp kubeconfig $HOME/.kube/config-mgmt

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/install_k3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/install_k3s.sh
@@ -28,7 +28,7 @@ publicIp=$(curl icanhazip.com)
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sLS https://get.k3sup.dev | sh
 sudo cp k3sup /usr/local/bin/k3sup
-sudo k3sup install --local --context arck3sdemo --ip $publicIp
+sudo k3sup install --local --context arck3sdemo --ip $publicIp --k3s-version 'v1.24.7+k3s1'
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo cp kubeconfig /home/${adminUsername}/.kube/config
 chown -R $adminUsername /home/${adminUsername}/.kube/

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/install_k3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/install_k3s.sh
@@ -10,7 +10,7 @@ publicIp=$(curl icanhazip.com)
 sudo mkdir ~/.kube
 sudo curl -sLS https://get.k3sup.dev | sh
 sudo cp k3sup /usr/local/bin/k3sup
-sudo k3sup install --local --context arck3sdemo --ip $publicIp --local-path ~/.kube/config
+sudo k3sup install --local --context arck3sdemo --ip $publicIp --local-path ~/.kube/config --k3s-version 'v1.24.7+k3s1'
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 
 # Installing Helm 3

--- a/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/az_connect_k3s.sh.tmpl
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/az_connect_k3s.sh.tmpl
@@ -10,7 +10,7 @@ source /tmp/vars.sh
 sudo mkdir ~/.kube
 sudo curl -sLS https://get.k3sup.dev | sh
 sudo cp k3sup /usr/local/bin/k3sup
-sudo k3sup install --local --context arck3sdemo --local-path ~/.kube/config
+sudo k3sup install --local --context arck3sdemo --local-path ~/.kube/config --k3s-version 'v1.24.7+k3s1'
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 
 # Installing Helm 3

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -118,7 +118,7 @@ echo ""
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sLS https://get.k3sup.dev | sh
-sudo k3sup install --local --context arcboxcapimgmt --k3s-extra-args '--no-deploy traefik'
+sudo k3sup install --local --context arcboxcapimgmt --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo cp kubeconfig ~/.kube/config
 sudo cp kubeconfig /home/${adminUsername}/.kube/config

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -45,7 +45,7 @@ publicIp=$(hostname -i)
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sLS https://get.k3sup.dev | sh
 # sudo cp k3sup /usr/local/bin/k3sup
-sudo k3sup install --local --context arcbox-k3s --ip $publicIp --k3s-extra-args '--no-deploy traefik'
+sudo k3sup install --local --context arcbox-k3s --ip $publicIp --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo cp kubeconfig /home/${adminUsername}/.kube/config
 sudo cp kubeconfig /home/${adminUsername}/.kube/config.staging


### PR DESCRIPTION
Hotfix to address an unknown breaking change in the latest Rancher K3s [upstream release](https://github.com/k3s-io/k3s/releases/tag/v1.25.3%2Bk3s1) which as a result causes k3sup-based k3s cluster to fail