### PR TITLE
Remove k3sup from ArcBox

### DIFF
--- a/azure_jumpstart_arcbox/ARM/kubernetes/ubuntuRancher.json
+++ b/azure_jumpstart_arcbox/ARM/kubernetes/ubuntuRancher.json
@@ -229,7 +229,7 @@
                 "settings": {
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('bash installK3s.sh', ' ', parameters('adminUsername'), ' ', parameters('spnClientId'), ' ', parameters('spnClientSecret'), ' ', parameters('spnTenantId'), ' ', parameters('vmName'), ' ', parameters('azureLocation'), ' ', parameters('stagingStorageAccountName'), ' ', parameters('logAnalyticsWorkspace'), ' ', parameters('deployBastion'))]",
+                    "commandToExecute": "[concat('bash installK3s.sh', ' ', parameters('adminUsername'), ' ', parameters('spnClientId'), ' ', parameters('spnClientSecret'), ' ', parameters('spnTenantId'), ' ', parameters('vmName'), ' ', parameters('azureLocation'), ' ', parameters('stagingStorageAccountName'), ' ', parameters('logAnalyticsWorkspace'), ' ', parameters('deployBastion'),  ' ', parameters('templateBaseUrl'))]",
                     "fileUris": [ "[concat(parameters('templateBaseUrl'), 'artifacts/installK3s.sh')]" ]
                 }
             }

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -115,17 +115,26 @@ export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 
 # Installing Rancher K3s cluster (single control plane)
 echo ""
+sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
-sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo kubectl config rename-context default arcboxcapimgmt --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config-mgmt
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
-chown -R $adminUsername /home/${adminUsername}/.kube/
-chown -R staginguser /home/${adminUsername}/.kube/config.staging
+sudo chown -R $adminUsername /home/${adminUsername}/.kube/
+sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
-export KUBECONFIG=/var/lib/waagent/custom-script/download/0/kubeconfig
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 kubectl config set-context arcboxcapimgmt
+
+
+
+
+
+
 
 # Installing clusterctl
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -115,7 +115,7 @@ export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 
 # Installing Rancher K3s cluster (single control plane)
 echo ""
-sudo mkdir ~/.kube
+sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -130,12 +130,6 @@ sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 kubectl config set-context arcboxcapimgmt
 
-
-
-
-
-
-
 # Installing clusterctl
 echo ""
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v${CLUSTERCTL_VERSION}/clusterctl-linux-amd64 -o clusterctl

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -113,19 +113,16 @@ export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
 export CLUSTER_IDENTITY_NAME="cluster-identity"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 
-# Installing Rancher K3s single node cluster using k3sup
+# Installing Rancher K3s cluster (single control plane)
 echo ""
 sudo mkdir ~/.kube
-sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
-curl -sLS https://get.k3sup.dev | sh
-sudo k3sup install --local --context arcboxcapimgmt --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
-sudo cp kubeconfig ~/.kube/config
-sudo cp kubeconfig /home/${adminUsername}/.kube/config
-sudo cp /var/lib/waagent/custom-script/download/0/kubeconfig /home/${adminUsername}/.kube/config-mgmt
-sudo cp kubeconfig /home/${adminUsername}/.kube/config.staging
-sudo chown -R $adminUsername /home/${adminUsername}/.kube/
-sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
+sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
+chown -R $adminUsername /home/${adminUsername}/.kube/
+chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
 export KUBECONFIG=/var/lib/waagent/custom-script/download/0/kubeconfig
 kubectl config set-context arcboxcapimgmt

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -86,6 +86,7 @@ export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.5.3" # Do not change!
 export KUBERNETES_VERSION="1.24.7" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.23.0" # Do not change!
+export K3S_VERSION="1.24.7+k3s1" # Do not change!
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"
@@ -117,7 +118,7 @@ export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 echo ""
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" INSTALL_K3S_VERSION=v${K3S_VERSION} sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcboxcapimgmt --kubeconfig /etc/rancher/k3s/k3s.yaml
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -264,6 +264,3 @@ sudo -u $adminUsername az storage azcopy blob upload --container $storageContain
 echo ""
 log="/home/${adminUsername}/jumpstart_logs/installCAPI.log"
 sudo -u $adminUsername az storage azcopy blob upload --container $storageContainerName --account-name $stagingStorageAccountName --account-key $storageAccountKey --source $log
-
-
-

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -42,7 +42,7 @@ while sleep 1; do sudo -s rsync -a /var/lib/waagent/custom-script/download/0/ins
 
 # Installing Rancher K3s cluster (single control plane)
 echo ""
-sudo mkdir ~/.kube
+sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -52,52 +52,17 @@ sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 sudo chown -R $adminUsername /home/${adminUsername}/.kube/
-sudo chown -R $adminUsername /home/${adminUsername}/.kube/config
 sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
-
-export KUBECONFIG=~/.kube/config
-# kubectl config set-context arcbox-k3s
-sleep 30
-kubectl get pods --all-namespaces
-echo ""
-echo ""
-echo ""
-sudo kubectl get pods --all-namespaces
-echo ""
-echo ""
-echo ""
-kubectl get pods --all-namespaces --kubeconfig /etc/rancher/k3s/k3s.yaml
-echo ""
-echo ""
-echo ""
-sudo kubectl get pods --all-namespaces --kubeconfig /etc/rancher/k3s/k3s.yaml
-
-echo ""
-echo "Making sure Rancher K3s cluster is ready..."
-echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig /etc/rancher/k3s/k3s.yaml
-echo ""
-echo ""
-echo ""
-sudo kubectl get nodes -o wide --kubeconfig /etc/rancher/k3s/k3s.yaml | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
-echo ""
-echo ""
-echo ""
-
-echo ""
-echo "Making sure Rancher K3s cluster is ready..."
-echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments
-echo ""
-echo ""
-echo ""
-sudo kubectl get nodes -o wide | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
-echo ""
-echo ""
-echo ""
 
 # Installing Helm 3
 sudo snap install helm --classic
+
+echo ""
+echo "Making sure Rancher K3s cluster is ready..."
+echo ""
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments -A >/dev/null
+sudo kubectl get nodes -o wide | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+echo ""
 
 # Installing Azure CLI & Azure Arc extensions
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -57,31 +57,20 @@ sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
 # export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 # kubectl config set-context arcbox-k3s
+kubectl get pods --all-namespaces
+echo ""
+echo ""
+echo ""
+sudo kubectl get pods --all-namespaces
 
 echo ""
 echo "Making sure Rancher K3s cluster is ready..."
 echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig /home/${adminUsername}/.kube/config -A
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments
 echo ""
 echo ""
 echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig ~/.kube/config -A
-echo ""
-echo ""
-echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig /etc/rancher/k3s/k3s.yaml -A
-echo ""
-echo ""
-echo ""
-sudo kubectl get nodes -o wide --kubeconfig /home/${adminUsername}/.kube/config -A | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
-echo ""
-echo ""
-echo ""
-sudo kubectl get nodes -o wide --kubeconfig --kubeconfig ~/.kube/config -A | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
-echo ""
-echo ""
-echo ""
-sudo kubectl get nodes -o wide --kubeconfig /etc/rancher/k3s/k3s.yaml -A | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+sudo kubectl get nodes -o wide | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
 echo ""
 echo ""
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -47,6 +47,7 @@ sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 sudo chown -R $adminUsername /home/${adminUsername}/.kube/

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -40,15 +40,13 @@ sudo curl -o /etc/profile.d/welcomeCAPI.sh ${templateBaseUrl}artifacts/welcomeK3
 sudo -u $adminUsername mkdir -p /home/${adminUsername}/jumpstart_logs
 while sleep 1; do sudo -s rsync -a /var/lib/waagent/custom-script/download/0/installK3s.log /home/${adminUsername}/jumpstart_logs/installK3s.log; done &
 
-# Installing Rancher K3s single master cluster using k3sup
-publicIp=$(hostname -i)
+# Installing Rancher K3s cluster (single control plane)
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
-curl -sLS https://get.k3sup.dev | sh
-# sudo cp k3sup /usr/local/bin/k3sup
-sudo k3sup install --local --context arcbox-k3s --ip $publicIp --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
-sudo cp kubeconfig /home/${adminUsername}/.kube/config
-sudo cp kubeconfig /home/${adminUsername}/.kube/config.staging
+sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 chown -R $adminUsername /home/${adminUsername}/.kube/
 chown -R staginguser /home/${adminUsername}/.kube/config.staging
 

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -52,10 +52,11 @@ sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 sudo chown -R $adminUsername /home/${adminUsername}/.kube/
+sudo chown -R $adminUsername /home/${adminUsername}/.kube/config
 sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-kubectl config set-context arcbox-k3s
+export KUBECONFIG=~/.kube/config
+# kubectl config set-context arcbox-k3s
 sleep 30
 kubectl get pods --all-namespaces
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -55,22 +55,30 @@ sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 sudo chown -R $adminUsername /home/${adminUsername}/.kube/
 sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
-# export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-# kubectl config set-context arcbox-k3s
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl config set-context arcbox-k3s
 kubectl get pods --all-namespaces
 echo ""
 echo ""
 echo ""
 sudo kubectl get pods --all-namespaces
+echo ""
+echo ""
+echo ""
+kubectl get pods --all-namespaces --kubeconfig /etc/rancher/k3s/k3s.yaml
+echo ""
+echo ""
+echo ""
+sudo kubectl get pods --all-namespaces --kubeconfig /etc/rancher/k3s/k3s.yaml
 
 echo ""
 echo "Making sure Rancher K3s cluster is ready..."
 echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig /etc/rancher/k3s/k3s.yaml
 echo ""
 echo ""
 echo ""
-sudo kubectl get nodes -o wide | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+sudo kubectl get nodes -o wide --kubeconfig /etc/rancher/k3s/k3s.yaml | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
 echo ""
 echo ""
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -42,8 +42,10 @@ while sleep 1; do sudo -s rsync -a /var/lib/waagent/custom-script/download/0/ins
 
 # Installing Rancher K3s cluster (single control plane)
 echo ""
+# publicIp=$(hostname -i)
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
+# curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik --node-external-ip ${publicIp}" sh -
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
@@ -53,8 +55,8 @@ sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 sudo chown -R $adminUsername /home/${adminUsername}/.kube/
 sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-kubectl config set-context arcbox-k3s
+# export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+# kubectl config set-context arcbox-k3s
 
 echo ""
 echo "Making sure Rancher K3s cluster is ready..."

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -46,7 +46,6 @@ publicIp=$(hostname -i)
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik --node-external-ip ${publicIp}" sh -
-# curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
@@ -57,6 +56,7 @@ sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 kubectl config set-context arcbox-k3s
+sleep 30
 kubectl get pods --all-namespaces
 echo ""
 echo ""
@@ -79,6 +79,18 @@ echo ""
 echo ""
 echo ""
 sudo kubectl get nodes -o wide --kubeconfig /etc/rancher/k3s/k3s.yaml | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+echo ""
+echo ""
+echo ""
+
+echo ""
+echo "Making sure Rancher K3s cluster is ready..."
+echo ""
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments
+echo ""
+echo ""
+echo ""
+sudo kubectl get nodes -o wide | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
 echo ""
 echo ""
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -38,7 +38,7 @@ chmod +x vars.sh
 . ./vars.sh
 
 # Creating login message of the day (motd)
-sudo curl -o /etc/profile.d/welcomeK3s.sh ${templateBaseUrl}artifacts/welcomeK3s.sh
+sudo curl -v -o /etc/profile.d/welcomeK3s.sh ${templateBaseUrl}artifacts/welcomeK3s.sh
 
 # Syncing this script log to 'jumpstart_logs' directory for ease of troubleshooting
 sudo -u $adminUsername mkdir -p /home/${adminUsername}/jumpstart_logs

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -61,7 +61,7 @@ sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 echo ""
 echo "Making sure Rancher K3s cluster is ready..."
 echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments -A >/dev/null
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments -A --kubeconfig /etc/rancher/k3s/k3s.yaml >/dev/null
 sudo kubectl get nodes -o wide | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
 echo ""
 

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -42,11 +42,11 @@ while sleep 1; do sudo -s rsync -a /var/lib/waagent/custom-script/download/0/ins
 
 # Installing Rancher K3s cluster (single control plane)
 echo ""
-# publicIp=$(hostname -i)
+publicIp=$(hostname -i)
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
-# curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik --node-external-ip ${publicIp}" sh -
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik --node-external-ip ${publicIp}" sh -
+# curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
@@ -61,8 +61,29 @@ sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 echo ""
 echo "Making sure Rancher K3s cluster is ready..."
 echo ""
-sudo kubectl wait --for=condition=Available --timeout=60s --all deployments -A --kubeconfig /etc/rancher/k3s/k3s.yaml >/dev/null
-sudo kubectl get nodes -o wide | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig /home/${adminUsername}/.kube/config -A
+echo ""
+echo ""
+echo ""
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig ~/.kube/config -A
+echo ""
+echo ""
+echo ""
+sudo kubectl wait --for=condition=Available --timeout=60s --all deployments --kubeconfig /etc/rancher/k3s/k3s.yaml -A
+echo ""
+echo ""
+echo ""
+sudo kubectl get nodes -o wide --kubeconfig /home/${adminUsername}/.kube/config -A | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+echo ""
+echo ""
+echo ""
+sudo kubectl get nodes -o wide --kubeconfig --kubeconfig ~/.kube/config -A | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+echo ""
+echo ""
+echo ""
+sudo kubectl get nodes -o wide --kubeconfig /etc/rancher/k3s/k3s.yaml -A | expand | awk 'length($0) > length(longest) { longest = $0 } { lines[NR] = $0 } END { gsub(/./, "=", longest); print "/=" longest "=\\"; n = length(longest); for(i = 1; i <= NR; ++i) { printf("| %s %*s\n", lines[i], n - length(lines[i]) + 1, "|"); } print "\\=" longest "=/" }'
+echo ""
+echo ""
 echo ""
 
 # Installing Helm 3

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -52,6 +52,9 @@ sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 sudo chown -R $adminUsername /home/${adminUsername}/.kube/
 sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl config set-context arcbox-k3s
+
 echo ""
 echo "Making sure Rancher K3s cluster is ready..."
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -19,6 +19,7 @@ echo $location:$6 | awk '{print substr($1,2); }' >> vars.sh
 echo $stagingStorageAccountName:$7 | awk '{print substr($1,2); }' >> vars.sh
 echo $logAnalyticsWorkspace:$8 | awk '{print substr($1,2); }' >> vars.sh
 echo $deployBastion:$9 | awk '{print substr($1,2); }' >> vars.sh
+echo $templateBaseUrl:${10} | awk '{print substr($1,2); }' >> vars.sh
 
 sed -i '2s/^/export adminUsername=/' vars.sh
 sed -i '3s/^/export SPN_CLIENT_ID=/' vars.sh
@@ -29,6 +30,9 @@ sed -i '7s/^/export location=/' vars.sh
 sed -i '8s/^/export stagingStorageAccountName=/' vars.sh
 sed -i '9s/^/export logAnalyticsWorkspace=/' vars.sh
 sed -i '10s/^/export deployBastion=/' vars.sh
+sed -i '11s/^/export templateBaseUrl=/' vars.sh
+
+export K3S_VERSION="1.24.7+k3s1"
 
 chmod +x vars.sh
 . ./vars.sh
@@ -45,7 +49,7 @@ echo ""
 publicIp=$(hostname -i)
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
-curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik --node-external-ip ${publicIp}" INSTALL_K3S_VERSION="v1.24.7+k3s1" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik --node-external-ip ${publicIp}" INSTALL_K3S_VERSION=v${K3S_VERSION} sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
@@ -71,6 +75,7 @@ sudo -u $adminUsername az extension add --name connectedk8s
 sudo -u $adminUsername az extension add --name k8s-configuration
 sudo -u $adminUsername az extension add --name k8s-extension
 
+echo ""
 echo "Log in to Azure"
 sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 az -v

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -42,14 +42,15 @@ while sleep 1; do sudo -s rsync -a /var/lib/waagent/custom-script/download/0/ins
 
 # Installing Rancher K3s cluster (single control plane)
 echo ""
+sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
 sudo kubectl config rename-context default arcbox-k3s --kubeconfig /etc/rancher/k3s/k3s.yaml
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
 sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
-chown -R $adminUsername /home/${adminUsername}/.kube/
-chown -R staginguser /home/${adminUsername}/.kube/config.staging
+sudo chown -R $adminUsername /home/${adminUsername}/.kube/
+sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
 echo ""
 echo "Making sure Rancher K3s cluster is ready..."


### PR DESCRIPTION
This PR address Jumpstart enhancement for removing k3sup from ArcBox automation. 

### PR Summary

- Remove k3sup script and replace it with the upstream Rancher K3s installation method
- Introducing a new _K3S_VERSION_ environment variable for pindown and granular control of the installed K3s upstream version
- Adding message of the day (motd) to the _installK3s.sh_ script
- Adding the "_Making sure Rancher K3s cluster is ready..._" message to the _installK3s.sh_ script
- Minor optimization to the cluster extension installation code block in the _installK3s.sh_ script