### PR TITLE
Remove k3sup from Azure Arc-enabled data services automation

### DIFF
--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/Bootstrap.ps1
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/Bootstrap.ps1
@@ -16,7 +16,7 @@ param (
     [string]$deploySQLMI,
     [string]$SQLMIHA,    
     [string]$deployPostgreSQL,
-    [string]$ArcK8sClusterName,
+    [string]$capiArcDataClusterName,
     [string]$templateBaseUrl
 )
 
@@ -37,7 +37,7 @@ param (
 [System.Environment]::SetEnvironmentVariable('deploySQLMI', $deploySQLMI,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('SQLMIHA', $SQLMIHA,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('deployPostgreSQL', $deployPostgreSQL,[System.EnvironmentVariableTarget]::Machine)
-[System.Environment]::SetEnvironmentVariable('ArcK8sClusterName', $ArcK8sClusterName,[System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable('capiArcDataClusterName', $capiArcDataClusterName,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('templateBaseUrl', $templateBaseUrl,[System.EnvironmentVariableTarget]::Machine)
 
 # Create path

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/DataServicesLogonScript.ps1
@@ -2,7 +2,7 @@ Start-Transcript -Path C:\Temp\DataServicesLogonScript.log
 
 # Deployment environment variables
 $Env:TempDir = "C:\Temp"
-$connectedClusterName = $Env:ArcK8sClusterName
+$connectedClusterName = $Env:capiArcDataClusterName
 
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
@@ -131,7 +131,7 @@ $extensionId = az k8s-extension show --name arc-data-services `
 Start-Sleep -Seconds 20
 
 # Create Custom Location
-az customlocation create --name 'jumpstart-cl' `
+az customlocation create --name "$Env:capiArcDataClusterName-cl" `
                          --resource-group $Env:resourceGroup `
                          --namespace arc `
                          --host-resource-id $connectedClusterId `
@@ -143,7 +143,7 @@ Write-Host "`n"
 Write-Host "Deploying Azure Arc Data Controller"
 Write-Host "`n"
 
-$customLocationId = $(az customlocation show --name "jumpstart-cl" --resource-group $Env:resourceGroup --query id -o tsv)
+$customLocationId = $(az customlocation show --name "$Env:capiArcDataClusterName-cl" --resource-group $Env:resourceGroup --query id -o tsv)
 $workspaceId = $(az resource show --resource-group $Env:resourceGroup --name $Env:workspaceName --resource-type "Microsoft.OperationalInsights/workspaces" --query properties.customerId -o tsv)
 $workspaceKey = $(az monitor log-analytics workspace get-shared-keys --resource-group $Env:resourceGroup --workspace-name $Env:workspaceName --query primarySharedKey -o tsv)
 

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/DeployPostgreSQL.ps1
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/DeployPostgreSQL.ps1
@@ -2,15 +2,15 @@ Start-Transcript -Path C:\Temp\DeployPostgreSQL.log
 
 # Deployment environment variables
 $Env:TempDir = "C:\Temp"
-$controllerName = "jumpstart-dc"
+$controllerName = "jumpstart-dc" # This value needs to match the value of the data controller name as set by the ARM template deployment.
 
 # Deploying Azure Arc-enabled PostgreSQL
 Write-Host "`n"
 Write-Host "Deploying Azure Arc-enabled PostgreSQL"
 Write-Host "`n"
 
-$customLocationId = $(az customlocation show --name "jumpstart-cl" --resource-group $env:resourceGroup --query id -o tsv)
-$dataControllerId = $(az resource show --resource-group $env:resourceGroup --name $controllerName --resource-type "Microsoft.AzureArcData/dataControllers" --query id -o tsv)
+$customLocationId = $(az customlocation show --name "$Env:capiArcDataClusterName-cl" --resource-group $Env:resourceGroup --query id -o tsv)
+$dataControllerId = $(az resource show --resource-group $Env:resourceGroup --name $controllerName --resource-type "Microsoft.AzureArcData/dataControllers" --query id -o tsv)
 
 ################################################
 # Localize ARM template
@@ -35,11 +35,11 @@ $numWorkers = 1
 
 $PSQLParams = "$Env:TempDir\postgreSQL.parameters.json"
 
-(Get-Content -Path $PSQLParams) -replace 'resourceGroup-stage',$env:resourceGroup | Set-Content -Path $PSQLParams
+(Get-Content -Path $PSQLParams) -replace 'resourceGroup-stage',$Env:resourceGroup | Set-Content -Path $PSQLParams
 (Get-Content -Path $PSQLParams) -replace 'dataControllerId-stage',$dataControllerId | Set-Content -Path $PSQLParams
 (Get-Content -Path $PSQLParams) -replace 'customLocation-stage',$customLocationId | Set-Content -Path $PSQLParams
-(Get-Content -Path $PSQLParams) -replace 'subscriptionId-stage',$env:subscriptionId | Set-Content -Path $PSQLParams
-(Get-Content -Path $PSQLParams) -replace 'azdataPassword-stage',$env:AZDATA_PASSWORD | Set-Content -Path $PSQLParams
+(Get-Content -Path $PSQLParams) -replace 'subscriptionId-stage',$Env:subscriptionId | Set-Content -Path $PSQLParams
+(Get-Content -Path $PSQLParams) -replace 'azdataPassword-stage',$Env:AZDATA_PASSWORD | Set-Content -Path $PSQLParams
 (Get-Content -Path $PSQLParams) -replace 'serviceType-stage',$ServiceType | Set-Content -Path $PSQLParams
 (Get-Content -Path $PSQLParams) -replace 'coordinatorCoresRequest-stage',$coordinatorCoresRequest | Set-Content -Path $PSQLParams
 (Get-Content -Path $PSQLParams) -replace 'coordinatorMemoryRequest-stage',$coordinatorMemoryRequest | Set-Content -Path $PSQLParams
@@ -53,7 +53,7 @@ $PSQLParams = "$Env:TempDir\postgreSQL.parameters.json"
 (Get-Content -Path $PSQLParams) -replace 'backupsSize-stage',$backupsStorageSize | Set-Content -Path $PSQLParams
 (Get-Content -Path $PSQLParams) -replace 'numWorkersStage',$numWorkers | Set-Content -Path $PSQLParams
 
-az deployment group create --resource-group $env:resourceGroup `
+az deployment group create --resource-group $Env:resourceGroup `
                            --template-file "$Env:TempDir\postgreSQL.json" `
                            --parameters "$Env:TempDir\postgreSQL.parameters.json"
 Write-Host "`n"
@@ -94,11 +94,11 @@ $pgsqlstring = kubectl get postgresql jumpstartps -n arc -o=jsonpath='{.status.p
 # Replace placeholder values in settingsTemplate.json
 (Get-Content -Path $settingsTemplate) -replace 'arc_postgres_host',$pgsqlstring.split(":")[0] | Set-Content -Path $settingsTemplate
 (Get-Content -Path $settingsTemplate) -replace 'arc_postgres_port',$pgsqlstring.split(":")[1] | Set-Content -Path $settingsTemplate
-(Get-Content -Path $settingsTemplate) -replace 'ps_password',$env:AZDATA_PASSWORD | Set-Content -Path $settingsTemplate
+(Get-Content -Path $settingsTemplate) -replace 'ps_password',$Env:AZDATA_PASSWORD | Set-Content -Path $settingsTemplate
 
 
 # If SQL MI isn't being deployed, clean up settings file
-if ( $env:deploySQLMI -eq $false )
+if ( $Env:deploySQLMI -eq $false )
 {
      $string = Get-Content -Path $settingsTemplate | Select-Object -First 9 -Last 24
      $string | Set-Content -Path $settingsTemplate

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -18,7 +18,7 @@ echo $vmName:$5 | awk '{print substr($1,2); }' >> vars.sh
 echo $location:$6 | awk '{print substr($1,2); }' >> vars.sh
 echo $stagingStorageAccountName:$7 | awk '{print substr($1,2); }' >> vars.sh
 echo $logAnalyticsWorkspace:$8 | awk '{print substr($1,2); }' >> vars.sh
-echo $arcK8sClusterName:$9 | awk '{print substr($1,2); }' >> vars.sh
+echo $capiArcDataClusterName:$9 | awk '{print substr($1,2); }' >> vars.sh
 echo $templateBaseUrl:${10} | awk '{print substr($1,2); }' >> vars.sh
 sed -i '2s/^/export adminUsername=/' vars.sh
 sed -i '3s/^/export SPN_CLIENT_ID=/' vars.sh
@@ -28,7 +28,7 @@ sed -i '6s/^/export vmName=/' vars.sh
 sed -i '7s/^/export location=/' vars.sh
 sed -i '8s/^/export stagingStorageAccountName=/' vars.sh
 sed -i '9s/^/export logAnalyticsWorkspace=/' vars.sh
-sed -i '10s/^/export arcK8sClusterName=/' vars.sh
+sed -i '10s/^/export capiArcDataClusterName=/' vars.sh
 sed -i '11s/^/export templateBaseUrl=/' vars.sh
 
 chmod +x vars.sh
@@ -80,7 +80,7 @@ export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"
 export AZURE_LOCATION=$location # Name of the Azure datacenter location.
-export CLUSTER_NAME=$(echo "${arcK8sClusterName,,}") # Converting to lowercase case variable > # Name of the CAPI workload cluster. Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+export CLUSTER_NAME=$(echo "${capiArcDataClusterName,,}") # Converting to lowercase case variable > # Name of the CAPI workload cluster. Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
 export AZURE_SUBSCRIPTION_ID=$subscriptionId
 export AZURE_TENANT_ID=$SPN_TENANT_ID
 export AZURE_CLIENT_ID=$SPN_CLIENT_ID
@@ -218,19 +218,19 @@ sudo -u $adminUsername kubectl config rename-context "$CLUSTER_NAME-admin@$CLUST
 # Onboarding the cluster to Azure Arc
 echo ""
 workspaceResourceId=$(sudo -u $adminUsername az resource show --resource-group $AZURE_RESOURCE_GROUP --name $logAnalyticsWorkspace --resource-type "Microsoft.OperationalInsights/workspaces" --query id -o tsv)
-export guid=$(echo $RANDOM | md5sum | head -c 4; echo;)
-export arcK8sClusterName=$(echo "${arcK8sClusterName}"-"${guid}")
-sudo -u $adminUsername az connectedk8s connect --name $arcK8sClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_azure_arc_data_services' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
+# export guid=$(echo $RANDOM | md5sum | head -c 4; echo;)
+# export arcK8sClusterName=$(echo "${arcK8sClusterName}"-"${guid}")
+sudo -u $adminUsername az connectedk8s connect --name $capiArcDataClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_azure_arc_data_services' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 # Enabling Microsoft Defender for Containers and Container Insights cluster extensions
 echo ""
-sudo -u $adminUsername az k8s-extension create -n "azure-defender" --cluster-name $arcK8sClusterName --resource-group $AZURE_RESOURCE_GROUP --cluster-type connectedClusters --extension-type Microsoft.AzureDefender.Kubernetes --configuration-settings logAnalyticsWorkspaceResourceID=$workspaceResourceId --debug
+sudo -u $adminUsername az k8s-extension create -n "azure-defender" --cluster-name $capiArcDataClusterName --resource-group $AZURE_RESOURCE_GROUP --cluster-type connectedClusters --extension-type Microsoft.AzureDefender.Kubernetes --configuration-settings logAnalyticsWorkspaceResourceID=$workspaceResourceId --debug
 echo ""
-sudo -u $adminUsername az k8s-extension create --name "azuremonitor-containers" --cluster-name $arcK8sClusterName --resource-group $AZURE_RESOURCE_GROUP --cluster-type connectedClusters --extension-type Microsoft.AzureMonitor.Containers --configuration-settings logAnalyticsWorkspaceResourceID=$workspaceResourceId
+sudo -u $adminUsername az k8s-extension create --name "azuremonitor-containers" --cluster-name $capiArcDataClusterName --resource-group $AZURE_RESOURCE_GROUP --cluster-type connectedClusters --extension-type Microsoft.AzureMonitor.Containers --configuration-settings logAnalyticsWorkspaceResourceID=$workspaceResourceId
 
 # Enabling Azure Policy for Kubernetes on the cluster
 echo ""
-sudo -u $adminUsername az k8s-extension create --name "arc-azurepolicy" --cluster-name $arcK8sClusterName --resource-group $AZURE_RESOURCE_GROUP --cluster-type connectedClusters --extension-type Microsoft.PolicyInsights
+sudo -u $adminUsername az k8s-extension create --name "arc-azurepolicy" --cluster-name $capiArcDataClusterName --resource-group $AZURE_RESOURCE_GROUP --cluster-type connectedClusters --extension-type Microsoft.PolicyInsights
 
 # Deploying The Azure disk Container Storage Interface (CSI) Kubernetes driver
 echo ""

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -75,6 +75,7 @@ export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.5.3" # Do not change!
 export KUBERNETES_VERSION="1.24.7" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.23.0" # Do not change!
+export K3S_VERSION="1.24.7+k3s1" # Do not change!
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"
@@ -98,21 +99,21 @@ export AZURE_CLUSTER_IDENTITY_SECRET_NAME="cluster-identity-secret"
 export CLUSTER_IDENTITY_NAME="cluster-identity"
 export AZURE_CLUSTER_IDENTITY_SECRET_NAMESPACE="default"
 
-# Installing Rancher K3s single node cluster using k3sup
+# Installing Rancher K3s cluster (single control plane)
 echo ""
 sudo mkdir ~/.kube
 sudo -u $adminUsername mkdir /home/${adminUsername}/.kube
-curl -sLS https://get.k3sup.dev | sh
-sudo k3sup install --local --context arcdatacapimgmt --k3s-extra-args '--no-deploy traefik' --k3s-version 'v1.24.7+k3s1'
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable traefik" INSTALL_K3S_VERSION=v${K3S_VERSION} sh -
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml
-sudo cp kubeconfig ~/.kube/config
-sudo cp kubeconfig /home/${adminUsername}/.kube/config
-sudo cp /var/lib/waagent/custom-script/download/0/kubeconfig /home/${adminUsername}/.kube/config-mgmt
-sudo cp kubeconfig /home/${adminUsername}/.kube/config.staging
+sudo kubectl config rename-context default arcdatacapimgmt --kubeconfig /etc/rancher/k3s/k3s.yaml
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config-mgmt
+sudo cp /etc/rancher/k3s/k3s.yaml /home/${adminUsername}/.kube/config.staging
 sudo chown -R $adminUsername /home/${adminUsername}/.kube/
 sudo chown -R staginguser /home/${adminUsername}/.kube/config.staging
 
-export KUBECONFIG=/var/lib/waagent/custom-script/download/0/kubeconfig
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 kubectl config set-context arcdatacapimgmt
 
 # Installing clusterctl

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -218,8 +218,6 @@ sudo -u $adminUsername kubectl config rename-context "$CLUSTER_NAME-admin@$CLUST
 # Onboarding the cluster to Azure Arc
 echo ""
 workspaceResourceId=$(sudo -u $adminUsername az resource show --resource-group $AZURE_RESOURCE_GROUP --name $logAnalyticsWorkspace --resource-type "Microsoft.OperationalInsights/workspaces" --query id -o tsv)
-# export guid=$(echo $RANDOM | md5sum | head -c 4; echo;)
-# export arcK8sClusterName=$(echo "${arcK8sClusterName}"-"${guid}")
 sudo -u $adminUsername az connectedk8s connect --name $capiArcDataClusterName --resource-group $AZURE_RESOURCE_GROUP --location $location --tags 'Project=jumpstart_azure_arc_data_services' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 
 # Enabling Microsoft Defender for Containers and Container Insights cluster extensions

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/azuredeploy.json
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/azuredeploy.json
@@ -100,7 +100,14 @@
       "metadata": {
         "description": "the Azure Bastion host name"
       }
-    }
+    },
+    "guid":{
+      "type": "string",
+      "metadata": {
+        "description": "Random GUID for cluster names"
+      },
+      "defaultValue": "[substring(newGuid(),0,4)]"
+    }    
   },
   "variables": {
     "templateBaseUrl": "[concat('https://raw.githubusercontent.com/', parameters('githubAccount'), '/azure_arc/', parameters('githubBranch'), '/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/')]",
@@ -109,6 +116,7 @@
     "mgmtStagingStorageUrl": "[uri(variables('templateBaseUrl'), 'mgmtStagingStorage.json')]",
     "logAnalyticsUrl": "[uri(variables('templateBaseUrl'), 'logAnalytics.json')]",
     "VNETUrl": "[uri(variables('templateBaseUrl'), 'VNET.json')]",
+    "capiArcDataClusterName": "[concat('ArcBox-CAPI-Data','-',parameters('guid'))]",
     // Virtual Network configuration
     "virtualNetworkName": "Arc-Data-VNet",
     "subnetName": "Arc-Data-Subnet",
@@ -194,7 +202,10 @@
           },
           "deployBastion": {
             "value": "[parameters('deployBastion')]"
-          }
+          },
+          "capiArcDataClusterName" : {
+            "value": "[variables('capiArcDataClusterName')]"
+          }          
         }
       }
     },
@@ -264,7 +275,10 @@
           },
           "bastionSubnetRef": {
             "value": "[variables('bastionSubnetRef')]"
-          }
+          },
+          "capiArcDataClusterName" : {
+            "value": "[variables('capiArcDataClusterName')]"
+          }          
         }
       }
     },

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/clientVm.json
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/clientVm.json
@@ -15,7 +15,7 @@
         "description": "The name of your Virtual Machine"
       }
     },
-    "ArcK8sClusterName": {
+    "capiArcDataClusterName": {
       "type": "string",
       "defaultValue": "Arc-DataSvc-CAPI",
       "metadata": {
@@ -336,7 +336,7 @@
           "fileUris": [
             "[uri(parameters('templateBaseUrl'), 'artifacts/Bootstrap.ps1')]"
           ],
-          "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1', ' -adminUsername ', parameters('windowsAdminUsername'), ' -spnClientId ', parameters('spnClientId'), ' -spnClientSecret ', parameters('spnClientSecret'), ' -spnTenantId ', parameters('spnTenantId'), ' -spnAuthority ', parameters('spnAuthority'), ' -subscriptionId ', subscription().subscriptionId, ' -resourceGroup ', resourceGroup().name, ' -azdataUsername ', parameters('azdataUsername'), ' -azdataPassword ', parameters('azdataPassword'), ' -acceptEula ', parameters('acceptEula'), ' -arcDcName ', parameters('arcDcName'), ' -azureLocation ', parameters('azureLocation'), ' -stagingStorageAccountName ', parameters('stagingStorageAccountName'), ' -workspaceName ', parameters('workspaceName'), ' -ArcK8sClusterName ', parameters('ArcK8sClusterName'), ' -deploySQLMI ', parameters('deploySQLMI'), ' -SQLMIHA ', parameters('SQLMIHA'), ' -deployPostgreSQL ', parameters('deployPostgreSQL'), ' -templateBaseUrl ', parameters('templateBaseUrl'))]"
+          "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1', ' -adminUsername ', parameters('windowsAdminUsername'), ' -spnClientId ', parameters('spnClientId'), ' -spnClientSecret ', parameters('spnClientSecret'), ' -spnTenantId ', parameters('spnTenantId'), ' -spnAuthority ', parameters('spnAuthority'), ' -subscriptionId ', subscription().subscriptionId, ' -resourceGroup ', resourceGroup().name, ' -azdataUsername ', parameters('azdataUsername'), ' -azdataPassword ', parameters('azdataPassword'), ' -acceptEula ', parameters('acceptEula'), ' -arcDcName ', parameters('arcDcName'), ' -azureLocation ', parameters('azureLocation'), ' -stagingStorageAccountName ', parameters('stagingStorageAccountName'), ' -workspaceName ', parameters('workspaceName'), ' -capiArcDataClusterName ', parameters('capiArcDataClusterName'), ' -deploySQLMI ', parameters('deploySQLMI'), ' -SQLMIHA ', parameters('SQLMIHA'), ' -deployPostgreSQL ', parameters('deployPostgreSQL'), ' -templateBaseUrl ', parameters('templateBaseUrl'))]"
         }
       }
     },

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/ubuntuCapi.json
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/ubuntuCapi.json
@@ -15,7 +15,7 @@
                 "description": "The name of you Virtual Machine."
             }
         },
-        "ArcK8sClusterName": {
+        "capiArcDataClusterName": {
             "type": "string",
             "defaultValue": "Arc-DataSvc-CAPI",
             "metadata": {
@@ -320,7 +320,7 @@
                 "settings": {
                 },
                 "protectedSettings": {
-                    "commandToExecute": "[concat('bash installCAPI.sh', ' ', parameters('adminUsername'), ' ', parameters('spnClientId'), ' ', parameters('spnClientSecret'), ' ', parameters('spnTenantId'), ' ', parameters('vmName'), ' ', parameters('azureLocation'), ' ', parameters('stagingStorageAccountName'), ' ', parameters('logAnalyticsWorkspaceName'), ' ', parameters('ArcK8sClusterName'), ' ',parameters('templateBaseUrl'))]",
+                    "commandToExecute": "[concat('bash installCAPI.sh', ' ', parameters('adminUsername'), ' ', parameters('spnClientId'), ' ', parameters('spnClientSecret'), ' ', parameters('spnTenantId'), ' ', parameters('vmName'), ' ', parameters('azureLocation'), ' ', parameters('stagingStorageAccountName'), ' ', parameters('logAnalyticsWorkspaceName'), ' ', parameters('capiArcDataClusterName'), ' ',parameters('templateBaseUrl'))]",
                     "fileUris": [
                         "[uri(parameters('templateBaseUrl'), 'artifacts/installCAPI.sh')]"
                     ]


### PR DESCRIPTION
This PR address Jumpstart enhancement for removing k3sup from ArcBox automation. 

### PR Summary

- Remove k3sup script and replace it with the upstream Rancher K3s installation method
- Introducing a new _K3S_VERSION_ environment variable for pindown and granular control of the installed K3s upstream version
- Changing the _ArcK8sClusterName_ name to _capiArcDataClusterName_
- Change Azure Arc-enabled Kubernetes cluster resource name to use GUID same as in ArcBox
- Change Custom Location resource name to use GUID same as in ArcBox
- Updating "_$env:_" to "_$Env:_"