### PR TITLE
removing optional docker registry settings from Arc data controller ARM templates

### DIFF
--- a/azure_arc_data_jumpstart/aks/ARM/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/aks/ARM/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/aks/ARM/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/aks/ARM/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
     "dockerRegistryCredential": {
       "value": "arc-private-registry"
     },
-    "dockerImagePullPolicy": {
-      "value": "Always"
-    },
-    "dockerImageTag": {
-      "value": "v1.15.0_2023-01-10"
-    },
-    "dockerRegistry": {
-      "value": "mcr.microsoft.com"
-    },
-    "dockerRepository": {
-      "value": "arcdata"
-    },
     "dataStorageClass": {
       "value": "managed-premium"
     },

--- a/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
     "dockerRegistryCredential": {
       "value": "arc-private-registry"
     },
-    "dockerImagePullPolicy": {
-      "value": "Always"
-    },
-    "dockerImageTag": {
-      "value": "v1.15.0_2023-01-10"
-    },
-    "dockerRegistry": {
-      "value": "mcr.microsoft.com"
-    },
-    "dockerRepository": {
-      "value": "arcdata"
-    },
     "dataStorageClass": {
       "value": "managed-premium"
     },

--- a/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
     "dockerRegistryCredential": {
       "value": "arc-private-registry"
     },
-    "dockerImagePullPolicy": {
-      "value": "Always"
-    },
-    "dockerImageTag": {
-      "value": "v1.15.0_2023-01-10"
-    },
-    "dockerRegistry": {
-      "value": "mcr.microsoft.com"
-    },
-    "dockerRepository": {
-      "value": "arcdata"
-    },
     "dataStorageClass": {
       "value": "managed-premium"
     },

--- a/azure_arc_data_jumpstart/aro/ARM/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/aro/ARM/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/aro/ARM/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/aro/ARM/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
     "dockerRegistryCredential": {
       "value": "arc-private-registry"
     },
-    "dockerImagePullPolicy": {
-      "value": "Always"
-    },
-    "dockerImageTag": {
-      "value": "v1.15.0_2023-01-10"
-    },
-    "dockerRegistry": {
-      "value": "mcr.microsoft.com"
-    },
-    "dockerRepository": {
-      "value": "arcdata"
-    },
     "dataStorageClass": {
       "value": "managed-premium"
     },

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
       "dockerRegistryCredential": {
         "value": "arc-private-registry"
       },
-      "dockerImagePullPolicy": {
-        "value": "Always"
-      },
-      "dockerImageTag": {
-        "value": "v1.15.0_2023-01-10"
-      },
-      "dockerRegistry": {
-        "value": "mcr.microsoft.com"
-      },
-      "dockerRepository": {
-        "value": "arcdata"
-      },
       "dataStorageClass": {
         "value": "managed-premium"
       },

--- a/azure_arc_data_jumpstart/eks/terraform/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/eks/terraform/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/eks/terraform/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/eks/terraform/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
     "dockerRegistryCredential": {
       "value": "arc-private-registry"
     },
-    "dockerImagePullPolicy": {
-      "value": "Always"
-    },
-    "dockerImageTag": {
-      "value": "v1.15.0_2023-01-10"
-    },
-    "dockerRegistry": {
-      "value": "mcr.microsoft.com"
-    },
-    "dockerRepository": {
-      "value": "arcdata"
-    },
     "dataStorageClass": {
       "value": "gp2"
     },

--- a/azure_arc_data_jumpstart/gke/terraform/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/gke/terraform/artifacts/dataController.json
@@ -57,18 +57,6 @@
         "dockerRegistryCredential": {
             "type": "String"
         },
-        "dockerImagePullPolicy": {
-            "type": "String"
-        },
-        "dockerImageTag": {
-            "type": "String"
-        },
-        "dockerRegistry": {
-            "type": "String"
-        },
-        "dockerRepository": {
-            "type": "String"
-        },
         "dataStorageClass": {
             "type": "String"
         },
@@ -138,12 +126,6 @@
                             "serviceAccount": "sa-arc-controller"
                         },
                         "infrastructure": "[parameters('infrastructure')]",
-                        "docker": {
-                            "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-                            "imageTag": "[parameters('dockerImageTag')]",
-                            "registry": "[parameters('dockerRegistry')]",
-                            "repository": "[parameters('dockerRepository')]"
-                        },
                         "security": {
                             "allowDumps": true,
                             "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/gke/terraform/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/gke/terraform/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
         "dockerRegistryCredential": {
             "value": "arc-private-registry"
         },
-        "dockerImagePullPolicy": {
-            "value": "Always"
-        },
-        "dockerImageTag": {
-            "value": "v1.15.0_2023-01-10"
-        },
-        "dockerRegistry": {
-            "value": "mcr.microsoft.com"
-        },
-        "dockerRepository": {
-            "value": "arcdata"
-        },
         "dataStorageClass": {
             "value": "premium-rwo"
         },

--- a/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/dataController.json
@@ -57,18 +57,6 @@
       "dockerRegistryCredential": {
         "type": "String"
       },
-      "dockerImagePullPolicy": {
-        "type": "String"
-      },
-      "dockerImageTag": {
-        "type": "String"
-      },
-      "dockerRegistry": {
-        "type": "String"
-      },
-      "dockerRepository": {
-        "type": "String"
-      },
       "dataStorageClass": {
         "type": "String"
       },
@@ -138,12 +126,6 @@
                 "serviceAccount": "sa-arc-controller"
               },
               "infrastructure": "[parameters('infrastructure')]",
-              "docker": {
-                "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-                "imageTag": "[parameters('dockerImageTag')]",
-                "registry": "[parameters('dockerRegistry')]",
-                "repository": "[parameters('dockerRepository')]"
-              },
               "security": {
                 "allowDumps": true,
                 "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
     "dockerRegistryCredential": {
       "value": "arc-private-registry"
     },
-    "dockerImagePullPolicy": {
-      "value": "Always"
-    },
-    "dockerImageTag": {
-      "value": "v1.15.0_2023-01-10"
-    },
-    "dockerRegistry": {
-      "value": "mcr.microsoft.com"
-    },
-    "dockerRepository": {
-      "value": "arcdata"
-    },
     "dataStorageClass": {
       "value": "managed-premium"
     },

--- a/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/dataController.json
+++ b/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/dataController.parameters.json
+++ b/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
     "dockerRegistryCredential": {
       "value": "arc-private-registry"
     },
-    "dockerImagePullPolicy": {
-      "value": "Always"
-    },
-    "dockerImageTag": {
-      "value": "v1.15.0_2023-01-10"
-    },
-    "dockerRegistry": {
-      "value": "mcr.microsoft.com"
-    },
-    "dockerRepository": {
-      "value": "arcdata"
-    },
     "dataStorageClass": {
       "value": "microk8s-hostpath"
     },

--- a/azure_jumpstart_arcbox/artifacts/dataController.json
+++ b/azure_jumpstart_arcbox/artifacts/dataController.json
@@ -57,18 +57,6 @@
     "dockerRegistryCredential": {
       "type": "String"
     },
-    "dockerImagePullPolicy": {
-      "type": "String"
-    },
-    "dockerImageTag": {
-      "type": "String"
-    },
-    "dockerRegistry": {
-      "type": "String"
-    },
-    "dockerRepository": {
-      "type": "String"
-    },
     "dataStorageClass": {
       "type": "String"
     },
@@ -138,12 +126,6 @@
               "serviceAccount": "sa-arc-controller"
             },
             "infrastructure": "[parameters('infrastructure')]",
-            "docker": {
-              "imagePullPolicy": "[parameters('dockerImagePullPolicy')]",
-              "imageTag": "[parameters('dockerImageTag')]",
-              "registry": "[parameters('dockerRegistry')]",
-              "repository": "[parameters('dockerRepository')]"
-            },
             "security": {
               "allowDumps": true,
               "allowNodeMetricsCollection": true,

--- a/azure_jumpstart_arcbox/artifacts/dataController.parameters.json
+++ b/azure_jumpstart_arcbox/artifacts/dataController.parameters.json
@@ -52,18 +52,6 @@
       "dockerRegistryCredential": {
         "value": "arc-private-registry"
       },
-      "dockerImagePullPolicy": {
-        "value": "Always"
-      },
-      "dockerImageTag": {
-        "value": "v1.15.0_2023-01-10"
-      },
-      "dockerRegistry": {
-        "value": "mcr.microsoft.com"
-      },
-      "dockerRepository": {
-        "value": "arcdata"
-      },
       "dataStorageClass": {
         "value": "managed-premium"
       },


### PR DESCRIPTION
This PR removes the docker registry settings from all Arc data controller ARM templates. These settings are now optional going forward, and the registry info will be extracted from the Arc data services k8s extension.