### PR TITLE
We need pass more two parameters on the command when we are using ARO

### DIFF
--- a/azure_arc_k8s_jumpstart/aro/arm_template/scripts/az_connect_aro.sh
+++ b/azure_arc_k8s_jumpstart/aro/arm_template/scripts/az_connect_aro.sh
@@ -81,5 +81,5 @@ user="kube:admin"
 context="default/$clusterName$user"
 
 echo "Connecting the cluster to Azure Arc"
-az connectedk8s connect --name $AZURE_ARC_CLUSTER_RESOURCE_NAME --resource-group $AZURE_RESOURCE_GROUP --location 'eastus' --tags 'Project=jumpstart_azure_arc_k8s' --kube-context $context --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
+az connectedk8s connect --name $AZURE_ARC_CLUSTER_RESOURCE_NAME --resource-group $AZURE_RESOURCE_GROUP --location 'eastus' --distribution openshift --infrastructure azure --tags 'Project=jumpstart_azure_arc_k8s' --kube-context $context --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 echo ""


### PR DESCRIPTION
We got different behavior from az connectedk8s connect when we are not using those parameters and we started to have some issue with the extensions from Azure ARC.