### PR TITLE
Monthly K8s version bump

### DIFF
--- a/azure_arc_app_services_jumpstart/aks/ARM/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/ARM/artifacts/AppServicesLogonScript.ps1
@@ -113,8 +113,8 @@ az k8s-extension create `
     --configuration-settings "customConfigMap=${namespace}/kube-environment-config" `
     --configuration-settings "envoy.annotations.service.beta.kubernetes.io/azure-load-balancer-resource-group=${aksClusterGroupName}" `
     --configuration-settings "logProcessor.appLogs.destination=log-analytics" `
-    --configuration-protected-settings "logProcessor.appLogs.logAnalyticsConfig.customerId=${logAnalyticsWorkspaceIdEnc}" `
-    --configuration-protected-settings "logProcessor.appLogs.logAnalyticsConfig.sharedKey=${logAnalyticsKeyEnc}"
+    --config-protected-settings "logProcessor.appLogs.logAnalyticsConfig.customerId=${logAnalyticsWorkspaceIdEnc}" `
+    --config-protected-settings "logProcessor.appLogs.logAnalyticsConfig.sharedKey=${logAnalyticsKeyEnc}"
 
 $extensionId=$(az k8s-extension show `
     --cluster-type connectedClusters `

--- a/azure_arc_app_services_jumpstart/aks/ARM/artifacts/ContainerAppsLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/ARM/artifacts/ContainerAppsLogonScript.ps1
@@ -102,8 +102,8 @@ az k8s-extension create `
     --configuration-settings "appsextensionNamespace=${namespace}" `
     --configuration-settings "CLUSTER_NAME=$Env:connectedClusterName" `
     --configuration-settings "logProcessor.appLogs.destination=log-analytics" `
-    --configuration-protected-settings "logProcessor.appLogs.logAnalyticsConfig.customerId=${logAnalyticsWorkspaceIdEnc}" `
-    --configuration-protected-settings "logProcessor.appLogs.logAnalyticsConfig.sharedKey=${logAnalyticsKeyEnc}"
+    --config-protected-settings "logProcessor.appLogs.logAnalyticsConfig.customerId=${logAnalyticsWorkspaceIdEnc}" `
+    --config-protected-settings "logProcessor.appLogs.logAnalyticsConfig.sharedKey=${logAnalyticsKeyEnc}"
 
 $kubectlMonShell = Start-Process -PassThru PowerShell {for (0 -lt 1) {kubectl get pod -n appplat-ns; Start-Sleep -Seconds 5; Clear-Host }}
 

--- a/azure_arc_app_services_jumpstart/aks/ARM/artifacts/deployApiMgmt.ps1
+++ b/azure_arc_app_services_jumpstart/aks/ARM/artifacts/deployApiMgmt.ps1
@@ -65,7 +65,7 @@ az k8s-extension create --cluster-type connectedClusters --cluster-name $env:clu
   --resource-group $env:resourceGroup --name apimgmt --extension-type Microsoft.ApiManagement.Gateway `
   --scope namespace --target-namespace apimgmt `
   --configuration-settings gateway.endpoint=$endpoint `
-  --configuration-protected-settings gateway.authKey=$token `
+  --config-protected-settings gateway.authKey=$token `
   --configuration-settings service.type='LoadBalancer' --release-train preview
 
 # Importing an API

--- a/azure_arc_app_services_jumpstart/aks/ARM/azuredeploy.json
+++ b/azure_arc_app_services_jumpstart/aks/ARM/azuredeploy.json
@@ -47,7 +47,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.24.9",
+            "defaultValue": "1.25.6",
             "type": "String",
             "metadata": {
                 "description": "The version of Kubernetes"

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/AppServicesLogonScript.ps1
@@ -89,8 +89,8 @@ az k8s-extension create `
    --configuration-settings "buildService.storageAccessMode=ReadWriteOnce"  `
    --configuration-settings "customConfigMap=${namespace}/kube-environment-config" `
    --configuration-settings "logProcessor.appLogs.destination=log-analytics" `
-   --configuration-protected-settings "logProcessor.appLogs.logAnalyticsConfig.customerId=${logAnalyticsWorkspaceIdEnc}" `
-   --configuration-protected-settings "logProcessor.appLogs.logAnalyticsConfig.sharedKey=${logAnalyticsKeyEnc}"
+   --config-protected-settings "logProcessor.appLogs.logAnalyticsConfig.customerId=${logAnalyticsWorkspaceIdEnc}" `
+   --config-protected-settings "logProcessor.appLogs.logAnalyticsConfig.sharedKey=${logAnalyticsKeyEnc}"
 
    $extensionId=$(az k8s-extension show `
    --cluster-type connectedClusters `

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/deployApiMgmt.ps1
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/deployApiMgmt.ps1
@@ -65,7 +65,7 @@ az k8s-extension create --cluster-type connectedClusters --cluster-name $env:clu
   --resource-group $env:resourceGroup --name apimgmt --extension-type Microsoft.ApiManagement.Gateway `
   --scope namespace --target-namespace apimgmt `
   --configuration-settings gateway.endpoint=$endpoint `
-  --configuration-protected-settings gateway.authKey=$token `
+  --config-protected-settings gateway.authKey=$token `
   --configuration-settings service.type='LoadBalancer' --release-train preview
 
 # Importing an API

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -85,13 +85,13 @@ sudo usermod -aG docker $adminUsername
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export KUBECTL_VERSION="1.24/stable" # Do not change!
-export CLUSTERCTL_VERSION="1.3.6" # Do not change!
+export KUBECTL_VERSION="1.27/stable" # Do not change!
+export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
-export CAPI_PROVIDER_VERSION="1.7.4" # Do not change!
-export KUBERNETES_VERSION="1.25.8" # Do not change!
+export CAPI_PROVIDER_VERSION="1.7.5" # Do not change!
+export KUBERNETES_VERSION="1.27.1" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" # Do not change!
-export K3S_VERSION="1.25.8+k3s1" # Do not change!
+export K3S_VERSION="1.27.1+k3s1" # Do not change!
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"

--- a/azure_arc_data_jumpstart/aks/ARM/azuredeploy.json
+++ b/azure_arc_data_jumpstart/aks/ARM/azuredeploy.json
@@ -47,7 +47,7 @@
       }
     },
     "kubernetesVersion": {
-      "defaultValue": "1.24.9",
+      "defaultValue": "1.25.6",
       "type": "string",
       "metadata": {
         "description": "The version of Kubernetes"

--- a/azure_arc_data_jumpstart/aks/DR/ARM/azuredeploy.json
+++ b/azure_arc_data_jumpstart/aks/DR/ARM/azuredeploy.json
@@ -47,7 +47,7 @@
       }
     },
     "kubernetesVersion": {
-      "defaultValue": "1.24.9",
+      "defaultValue": "1.25.6",
       "type": "string",
       "metadata": {
         "description": "The version of Kubernetes"

--- a/azure_arc_data_jumpstart/aks/Migration/ARM/azuredeploy.json
+++ b/azure_arc_data_jumpstart/aks/Migration/ARM/azuredeploy.json
@@ -47,7 +47,7 @@
       }
     },
     "kubernetesVersion": {
-      "defaultValue": "1.24.9",
+      "defaultValue": "1.25.6",
       "type": "string",
       "metadata": {
         "description": "The version of Kubernetes"

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -67,13 +67,13 @@ sudo usermod -aG docker $adminUsername
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export KUBECTL_VERSION="1.24/stable" # Do not change!
-export CLUSTERCTL_VERSION="1.3.6" # Do not change!
+export KUBECTL_VERSION="1.27/stable" # Do not change!
+export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
-export CAPI_PROVIDER_VERSION="1.7.4" # Do not change!
-export KUBERNETES_VERSION="1.25.8" # Do not change!
+export CAPI_PROVIDER_VERSION="1.7.5" # Do not change!
+export KUBERNETES_VERSION="1.27.1" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" # Do not change!
-export K3S_VERSION="1.26.3+k3s1" # Do not change!
+export K3S_VERSION="1.27.1+k3s1" # Do not change!
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"

--- a/azure_arc_k8s_jumpstart/aks/arm_template/azuredeploy.json
+++ b/azure_arc_k8s_jumpstart/aks/arm_template/azuredeploy.json
@@ -90,7 +90,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.24.9",
+            "defaultValue": "1.27.1",
             "type": "string",
             "metadata": {
                 "description": "The version of Kubernetes."

--- a/azure_arc_k8s_jumpstart/aks/arm_template/azuredeploy.parameters.json
+++ b/azure_arc_k8s_jumpstart/aks/arm_template/azuredeploy.parameters.json
@@ -18,7 +18,7 @@
             "value": "<Your Azure service principal password>"
         },
         "kubernetesVersion": {
-            "value": "<Kubernetes Version, e.g. 1.24.9>"
+            "value": "<Kubernetes Version, e.g. 1.27.1>"
         }
     }
 }

--- a/azure_arc_k8s_jumpstart/aks/terraform/variables.tf
+++ b/azure_arc_k8s_jumpstart/aks/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "location" {
 
 variable "kubernetes_version" {
   description = "Kubernetes version deployed"
-  default     = "1.24.9"
+  default     = "1.27.1"
 }
 
 variable "node_count" {

--- a/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/variable.tf
+++ b/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/variable.tf
@@ -165,7 +165,7 @@ variable "name" {
 variable "kubernetes_version" {
   type        = string
   description = "(Required) Version of Kubernetes specified when creating the AKS managed cluster. If not specified, the latest recommended version will be used at provisioning time (but won't auto-upgrade). NOTE: Upgrading your cluster may take up to 10 minutes per node."
-  default     = "1.24.9"
+  default     = "1.27.1"
 }
 
 variable "dns_prefix" {

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_azure/artifacts/installCAPI.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_azure/artifacts/installCAPI.sh
@@ -16,11 +16,11 @@ echo ""
 
   # Set deployment environment variables
   export GUID=$(echo $RANDOM | md5sum | head -c 4; echo;) # Do not change!
-  export CLUSTERCTL_VERSION="1.3.6" # Do not change!
+  export CLUSTERCTL_VERSION="1.4.1" # Do not change!
   export CAPI_PROVIDER="azure" # Do not change!
-  export CAPI_PROVIDER_VERSION="1.7.4" # Do not change!
-  export KUBERNETES_VERSION="1.25.8" # Do not change!
-  export K3S_VERSION="1.26.3+k3s1" # Do not change!
+  export CAPI_PROVIDER_VERSION="1.7.5" # Do not change!
+  export KUBERNETES_VERSION="1.27.1" # Do not change!
+  export K3S_VERSION="1.27.1+k3s1" # Do not change!
   export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
   export CONTROL_PLANE_MACHINE_COUNT="<Control Plane node count>" # Control Plane node count. For example: 1
   export WORKER_MACHINE_COUNT="<Workers node count>" # Workers node count. For example: 2

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
@@ -16,11 +16,11 @@ echo ""
 
   # Set deployment environment variables
   export GUID=$(echo $RANDOM | md5sum | head -c 4; echo;) # Do not change!
-  export CLUSTERCTL_VERSION="1.3.6" # Do not change!
+  export CLUSTERCTL_VERSION="1.4.1" # Do not change!
   export CAPI_PROVIDER="azure" # Do not change!
-  export CAPI_PROVIDER_VERSION="1.7.4" # Do not change!
-  export KUBERNETES_VERSION="1.25.8" # Do not change!
-  export K3S_VERSION="1.26.3+k3s1" # Do not change!
+  export CAPI_PROVIDER_VERSION="1.7.5" # Do not change!
+  export KUBERNETES_VERSION="1.27.1" # Do not change!
+  export K3S_VERSION="1.27.1+k3s1" # Do not change!
   export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
   export CONTROL_PLANE_MACHINE_COUNT="<Control Plane node count>" # Control Plane node count. For example: 1
   export WORKER_MACHINE_COUNT="<Workers node count>" # Workers node count. For example: 2

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/installK3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/installK3s.sh
@@ -28,7 +28,7 @@ sed -i '8s/^/export templateBaseUrl=/' vars.sh
 chmod +x vars.sh 
 . ./vars.sh
 
-export K3S_VERSION="1.26.3+k3s1" # Do not change!
+export K3S_VERSION="1.27.1+k3s1" # Do not change!
 
 # Creating login message of the day (motd)
 sudo curl -v -o /etc/profile.d/welcomeK3s.sh ${templateBaseUrl}scripts/welcomeK3s.sh

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/installK3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/installK3s.sh
@@ -28,7 +28,7 @@ sed -i '8s/^/export templateBaseUrl=/' vars.sh
 chmod +x vars.sh 
 . ./vars.sh
 
-export K3S_VERSION="1.26.3+k3s1" # Do not change!
+export K3S_VERSION="1.27.1+k3s1" # Do not change!
 
 # Creating login message of the day (motd)
 sudo curl -v -o /etc/profile.d/welcomeK3s.sh ${templateBaseUrl}scripts/welcomeK3s.sh

--- a/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/vars.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/vars.sh
@@ -14,4 +14,4 @@ export TF_VAR_vsphere_password='<vCenter Admin Password>'
 export TF_VAR_vsphere_server='<vCenter server FQDN/IP>'
 export TF_VAR_admin_user='<OS Admin Username>'
 export TF_VAR_admin_password='<OS Admin Password>'
-export K3S_VERSION="1.26.3+k3s1" # Do not change!
+export K3S_VERSION="1.27.1+k3s1" # Do not change!

--- a/azure_arc_ml_jumpstart/aks/arm_template/azuredeploy.json
+++ b/azure_arc_ml_jumpstart/aks/arm_template/azuredeploy.json
@@ -53,7 +53,7 @@
       }
     },
     "kubernetesVersion": {
-      "defaultValue": "1.24.9",
+      "defaultValue": "1.25.6",
       "type": "string",
       "metadata": {
         "description": "The version of Kubernetes."

--- a/azure_jumpstart_arcbox/ARM/kubernetes/aks.json
+++ b/azure_jumpstart_arcbox/ARM/kubernetes/aks.json
@@ -107,7 +107,7 @@
         "metadata": {
           "description": "The version of Kubernetes"
         },
-        "defaultValue" : "1.24.9"
+        "defaultValue" : "1.25.6"
       }
     },
     "variables": {

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -210,7 +210,7 @@ sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig apply -f https://raw.github
 echo ""
 CLUSTER_TOTAL_MACHINE_COUNT=`expr $CONTROL_PLANE_MACHINE_COUNT + $WORKER_MACHINE_COUNT`
 export CLUSTER_TOTAL_MACHINE_COUNT="$(echo $CLUSTER_TOTAL_MACHINE_COUNT)"
-until [[ $(sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig get nodes | grep -c -w "Ready") == $CLUSTER_TOTAL_MACHINE_COUNT ]]; do echo "Waiting all nodes to be in Ready state. This may take a few minutes..." && sleep 30
+until [[ $(sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig get nodes | grep -c -w "Ready") == $CLUSTER_TOTAL_MACHINE_COUNT ]]; do echo "Waiting all nodes to be in Ready state. This may take a few minutes..." && sleep 30 ;
 echo ""
 sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig label node -l '!node-role.kubernetes.io/master' node-role.kubernetes.io/worker=worker
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -78,13 +78,13 @@ sudo usermod -aG docker $adminUsername
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export KUBECTL_VERSION="1.26/stable" # Do not change!
+export KUBECTL_VERSION="1.27/stable" # Do not change!
 export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.8.3" # Do not change!
-export KUBERNETES_VERSION="1.26.4" # Do not change!
+export KUBERNETES_VERSION="1.27.1" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" # Do not change!
-export K3S_VERSION="1.26.4+k3s1" # Do not change!
+export K3S_VERSION="1.27.1+k3s1" # Do not change!
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"
@@ -210,7 +210,7 @@ sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig apply -f https://raw.github
 echo ""
 CLUSTER_TOTAL_MACHINE_COUNT=`expr $CONTROL_PLANE_MACHINE_COUNT + $WORKER_MACHINE_COUNT`
 export CLUSTER_TOTAL_MACHINE_COUNT="$(echo $CLUSTER_TOTAL_MACHINE_COUNT)"
-until [[ $(sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig get nodes | grep -c -w "Ready") == $CLUSTER_TOTAL_MACHINE_COUNT ]]; do echo "Waiting all nodes to be in Ready state. This may take a few minutes..." && sleep 30 ;
+until [[ $(sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig get nodes | grep -c -w "Ready") == $CLUSTER_TOTAL_MACHINE_COUNT ]]; do echo "Waiting all nodes to be in Ready state. This may take a few minutes..." && sleep 30 ; done 2> /dev/null
 echo ""
 sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig label node -l '!node-role.kubernetes.io/master' node-role.kubernetes.io/worker=worker
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -78,10 +78,10 @@ sudo usermod -aG docker $adminUsername
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export KUBECTL_VERSION="1.24/stable" # Do not change!
+export KUBECTL_VERSION="1.26/stable" # Do not change!
 export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
-export CAPI_PROVIDER_VERSION="1.8.3" # Do not change!
+export CAPI_PROVIDER_VERSION="1.7.5" # Do not change!
 export KUBERNETES_VERSION="1.26.4" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" # Do not change!
 export K3S_VERSION="1.26.4+k3s1" # Do not change!

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -78,13 +78,13 @@ sudo usermod -aG docker $adminUsername
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export KUBECTL_VERSION="1.24/stable" # Do not change!
-export CLUSTERCTL_VERSION="1.3.6" # Do not change!
+export KUBECTL_VERSION="1.26/stable" # Do not change!
+export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
-export CAPI_PROVIDER_VERSION="1.7.4" # Do not change!
-export KUBERNETES_VERSION="1.25.8" # Do not change!
+export CAPI_PROVIDER_VERSION="1.8.3" # Do not change!
+export KUBERNETES_VERSION="1.26.4" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" # Do not change!
-export K3S_VERSION="1.25.8+k3s1" # Do not change!
+export K3S_VERSION="1.26.4+k3s1" # Do not change!
 export AZURE_ENVIRONMENT="AzurePublicCloud" # Do not change!
 export CONTROL_PLANE_MACHINE_COUNT="3" # Do not change!
 export WORKER_MACHINE_COUNT="3"

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -81,7 +81,7 @@ sudo snap install kustomize
 export KUBECTL_VERSION="1.26/stable" # Do not change!
 export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
-export CAPI_PROVIDER_VERSION="1.7.5" # Do not change!
+export CAPI_PROVIDER_VERSION="1.8.3" # Do not change!
 export KUBERNETES_VERSION="1.26.4" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" # Do not change!
 export K3S_VERSION="1.26.4+k3s1" # Do not change!
@@ -210,7 +210,7 @@ sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig apply -f https://raw.github
 echo ""
 CLUSTER_TOTAL_MACHINE_COUNT=`expr $CONTROL_PLANE_MACHINE_COUNT + $WORKER_MACHINE_COUNT`
 export CLUSTER_TOTAL_MACHINE_COUNT="$(echo $CLUSTER_TOTAL_MACHINE_COUNT)"
-until [[ $(sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig get nodes | grep -c -w "Ready") == $CLUSTER_TOTAL_MACHINE_COUNT ]]; do echo "Waiting all nodes to be in Ready state. This may take a few minutes..." && sleep 30 ; done 2> /dev/null
+until [[ $(sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig get nodes | grep -c -w "Ready") == $CLUSTER_TOTAL_MACHINE_COUNT ]]; do echo "Waiting all nodes to be in Ready state. This may take a few minutes..." && sleep 30
 echo ""
 sudo kubectl --kubeconfig=./$CLUSTER_NAME.kubeconfig label node -l '!node-role.kubernetes.io/master' node-role.kubernetes.io/worker=worker
 echo ""

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -78,7 +78,7 @@ sudo usermod -aG docker $adminUsername
 sudo snap install kustomize
 
 # Set CAPI deployment environment variables
-export KUBECTL_VERSION="1.26/stable" # Do not change!
+export KUBECTL_VERSION="1.24/stable" # Do not change!
 export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
 export CAPI_PROVIDER_VERSION="1.8.3" # Do not change!

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -81,7 +81,7 @@ sudo snap install kustomize
 export KUBECTL_VERSION="1.27/stable" # Do not change!
 export CLUSTERCTL_VERSION="1.4.1" # Do not change!
 export CAPI_PROVIDER="azure" # Do not change!
-export CAPI_PROVIDER_VERSION="1.8.3" # Do not change!
+export CAPI_PROVIDER_VERSION="1.7.5" # Do not change!
 export KUBERNETES_VERSION="1.27.1" # Do not change!
 export AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" # Do not change!
 export K3S_VERSION="1.27.1+k3s1" # Do not change!

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -32,7 +32,7 @@ sed -i '9s/^/export logAnalyticsWorkspace=/' vars.sh
 sed -i '10s/^/export deployBastion=/' vars.sh
 sed -i '11s/^/export templateBaseUrl=/' vars.sh
 
-export K3S_VERSION="1.26.3+k3s1"
+export K3S_VERSION="1.26.4+k3s1"
 
 chmod +x vars.sh
 . ./vars.sh

--- a/azure_jumpstart_arcbox/bicep/kubernetes/aks.bicep
+++ b/azure_jumpstart_arcbox/bicep/kubernetes/aks.bicep
@@ -50,7 +50,7 @@ param enableRBAC bool = true
 param osType string = 'Linux'
 
 @description('The version of Kubernetes')
-param kubernetesVersion string = '1.24.9'
+param kubernetesVersion string = '1.25.6'
 
 var serviceCidr_primary = '10.20.64.0/19'
 var dnsServiceIP_primary = '10.20.64.10'

--- a/azure_jumpstart_arcbox/terraform/modules/kubernetes/aks/main.tf
+++ b/azure_jumpstart_arcbox/terraform/modules/kubernetes/aks/main.tf
@@ -82,7 +82,7 @@ variable "os_type" {
 variable "Kubernetes_version" {
   type        = string
   description = "The version of Kubernetes"
-  default     = "1.24.9"
+  default     = "1.25.6"
 }
 
 locals {


### PR DESCRIPTION
Monthly Kubernetes versions bump:

- CLUSTERCTL_VERSION="1.3.6" ==> 1.4.1
- CAPI_PROVIDER_VERSION="1.7.4" ==> 1.7.5
- KUBERNETES_VERSION="1.26.4" ==> 1.27.1
- K3S_VERSION="1.26.4+k3s1" ==> 1.27.1+k3s1
- AZURE_DISK_CSI_DRIVER_VERSION="1.26.3" ==> No change
- AKS 1.24.9 => 1.25.6