### PR TITLE
update max length of envName (aka RG name) to what's supported by ARM

### DIFF
--- a/azure_jumpstart_ag/bicep/main.azd.bicep
+++ b/azure_jumpstart_ag/bicep/main.azd.bicep
@@ -9,7 +9,7 @@ param spnClientSecret string
 param spnTenantId string
 
 @minLength(1)
-@maxLength(17)
+@maxLength(77)
 @description('Prefix for resource group, i.e. {name}-rg')
 param envName string
 


### PR DESCRIPTION
Details: https://learn.microsoft.com/en-us/azure/templates/microsoft.resources/resourcegroups?tabs=bicep&pivots=deployment-language-bicep

using 77 instead of 90 because we append `-rg` to the name.