### PR TITLE
Ag aks bump

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1147,8 +1147,8 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries) {
                         $retryCount++
-                        Write-Host "[$(Get-Date -Format t)] INFO: Attempting to re-install $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
-                        Write-Host "[$(Get-Date -Format t)] INFO: Deleting $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                        #Write-Host "[$(Get-Date -Format t)] INFO: Attempting to re-install $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                        #Write-Host "[$(Get-Date -Format t)] INFO: Deleting $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
                         az k8s-configuration flux delete `
                         --resource-group $resourceGroup `
                         --cluster-name $clusterName `
@@ -1160,7 +1160,7 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                         | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
 
                         Start-Sleep -Seconds 10
-                        Write-Host "[$(Get-Date -Format t)] INFO: Re-creating $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                        #Write-Host "[$(Get-Date -Format t)] INFO: Re-creating $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
 
                         az k8s-configuration flux create `
                         --cluster-name $clusterName `

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1146,7 +1146,7 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                         Start-Sleep -Seconds 20
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries) {
-                        Start-Sleep -Seconds 30
+                        Start-Sleep -Seconds 20
                         $configStatus = $(az k8s-configuration flux show --name $configName --cluster-name $clusterName --cluster-type $type --resource-group $resourceGroup -o json) | convertFrom-JSON
                         if($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries){
                             $retryCount++
@@ -1161,10 +1161,10 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                             --yes `
                             --only-show-errors `
                             | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
-    
+
                             Start-Sleep -Seconds 10
                             Write-Host "[$(Get-Date -Format t)] INFO: Re-creating $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
-    
+
                             az k8s-configuration flux create `
                             --cluster-name $clusterName `
                             --resource-group $resourceGroup `

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1146,35 +1146,39 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                         Start-Sleep -Seconds 20
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries) {
-                        <#$retryCount++
-                        #Write-Host "[$(Get-Date -Format t)] INFO: Attempting to re-install $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
-                        #Write-Host "[$(Get-Date -Format t)] INFO: Deleting $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
-                        az k8s-configuration flux delete `
-                        --resource-group $resourceGroup `
-                        --cluster-name $clusterName `
-                        --cluster-type $type `
-                        --name $configName `
-                        --force `
-                        --yes `
-                        --only-show-errors `
+                        Start-Sleep -Seconds 30
+                        $configStatus = $(az k8s-configuration flux show --name $configName --cluster-name $clusterName --cluster-type $type --resource-group $resourceGroup -o json) | convertFrom-JSON
+                        if($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries){
+                            $retryCount++
+                            Write-Host "[$(Get-Date -Format t)] INFO: Attempting to re-install $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                            Write-Host "[$(Get-Date -Format t)] INFO: Deleting $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                            az k8s-configuration flux delete `
+                            --resource-group $resourceGroup `
+                            --cluster-name $clusterName `
+                            --cluster-type $type `
+                            --name $configName `
+                            --force `
+                            --yes `
+                            --only-show-errors `
+                            | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+    
+                            Start-Sleep -Seconds 10
+                            Write-Host "[$(Get-Date -Format t)] INFO: Re-creating $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+    
+                            az k8s-configuration flux create `
+                            --cluster-name $clusterName `
+                            --resource-group $resourceGroup `
+                            --name $configName `
+                            --cluster-type $type `
+                            --url $appClonedRepo `
+                            --branch $branch `
+                            --sync-interval 5s `
+                            --kustomization name=$appName path=$appPath/$store prune=true `
+                            --timeout 30m `
+                            --namespace $namespace `
+                            --only-show-errors `
                         | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
-
-                        Start-Sleep -Seconds 10
-                        #Write-Host "[$(Get-Date -Format t)] INFO: Re-creating $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
-
-                        az k8s-configuration flux create `
-                        --cluster-name $clusterName `
-                        --resource-group $resourceGroup `
-                        --name $configName `
-                        --cluster-type $type `
-                        --url $appClonedRepo `
-                        --branch $branch `
-                        --sync-interval 5s `
-                        --kustomization name=$appName path=$appPath/$store prune=true `
-                        --timeout 30m `
-                        --namespace $namespace `
-                        --only-show-errors `
-                    | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")#>
+                        }
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -eq $maxRetries){
                         Write-Host "[$(Get-Date -Format t)] ERROR: GitOps configuration $configName has failed on $clusterName. Exiting..." -ForegroundColor White -BackgroundColor Red | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1146,7 +1146,7 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                         Start-Sleep -Seconds 20
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries) {
-                        $retryCount++
+                        <#$retryCount++
                         #Write-Host "[$(Get-Date -Format t)] INFO: Attempting to re-install $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
                         #Write-Host "[$(Get-Date -Format t)] INFO: Deleting $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
                         az k8s-configuration flux delete `
@@ -1174,7 +1174,7 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                         --timeout 30m `
                         --namespace $namespace `
                         --only-show-errors `
-                    | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                    | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")#>
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -eq $maxRetries){
                         Write-Host "[$(Get-Date -Format t)] ERROR: GitOps configuration $configName has failed on $clusterName. Exiting..." -ForegroundColor White -BackgroundColor Red | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")

--- a/azure_jumpstart_ag/bicep/kubernetes/aks.bicep
+++ b/azure_jumpstart_ag/bicep/kubernetes/aks.bicep
@@ -62,7 +62,7 @@ param osType string = 'Linux'
 var tier  = 'free'
 
 @description('The version of Kubernetes')
-param kubernetesVersion string = '1.24.9'
+param kubernetesVersion string = '1.25.6'
 
 var serviceCidr_staging = '10.21.64.0/19'
 var dnsServiceIP_staging = '10.21.64.10'


### PR DESCRIPTION
- Bumped up AKS version to 1.25.6
- Added native helm release retry logic while keeping our manual retry logic as a third option in case of failure