### PR TITLE
Flux installation optimizations

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1112,7 +1112,11 @@ foreach ($resource in $resources) {
 
                 try {
 
-                    az k8s-extension delete --name "flux" --cluster-name $resourceName --resource-group $Env:resourceGroup --cluster-type $ClusterType --force --yes
+                    if ($extension) {
+
+                        az k8s-extension delete --name "flux" --cluster-name $resourceName --resource-group $Env:resourceGroup --cluster-type $ClusterType --force --yes
+
+                     }
 
                     az k8s-extension create --name "flux" --extension-type "microsoft.flux" --cluster-name $resourceName --resource-group $Env:resourceGroup --cluster-type $ClusterType --output json | ConvertFrom-Json -OutVariable extension
 

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1775,12 +1775,7 @@ namespace Win32{
 Add-Type $code
 [Win32.Wallpaper]::SetWallpaper($imgPath)
 
-Write-Host "[$(Get-Date -Format t)] INFO: Dev Tools Installation background job:" -ForegroundColor Green
-
-$DevToolsInstallationJob
-$DevToolsInstallationJob | Wait-Job | Receive-Job | Tee-Object -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\ToolsSetup.log") -Append
-
-Write-Host "[$(Get-Date -Format t)] INFO: Starting Docker Desktop after Dev Tools Installation background job completed." -ForegroundColor Green
+Write-Host "[$(Get-Date -Format t)] INFO: Starting Docker Desktop" -ForegroundColor Green
 Start-Process "C:\Program Files\Docker\Docker\Docker Desktop.exe"
 
 $endTime = Get-Date

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1159,7 +1159,7 @@ $FluxExtensionJobs | Format-Table Name,PSBeginTime,PSEndTime -AutoSize
 $jobs | Remove-Job
 
 # Abort if Flux-extension fails on any cluster
-if ($FluxExtensionJobs | Where-Object $PSItem.ProvisioningState -ne 'Succeeded') {
+if ($FluxExtensionJobs | Where-Object ProvisioningState -ne 'Succeeded') {
 
     throw "One or more Flux-extension deployments failed - aborting"
 
@@ -1789,3 +1789,5 @@ Write-Host "[$(Get-Date -Format t)] INFO: Deployment is complete. Deployment tim
 Write-Host
 
 Stop-Transcript
+
+Wait-Debugger

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1137,7 +1137,7 @@ foreach ($resource in $resources) {
 
             }
 
-            $ProvisioningState = $extension.ProvisioningState
+            $ProvisioningState = $extension.ProvisioningState.ToString()
 
             [PSCustomObject]@{
                 ResourceName = $resourceName
@@ -1153,7 +1153,7 @@ foreach ($resource in $resources) {
 # Wait for all jobs to complete
 $FluxExtensionJobs = $jobs | Wait-Job | Receive-Job -Keep
 
-$FluxExtensionJobs | Format-Table Name,PSBeginTime,PSEndTime -AutoSize
+$jobs | Format-Table Name,PSBeginTime,PSEndTime -AutoSize
 
 # Clean up jobs
 $jobs | Remove-Job
@@ -1789,5 +1789,3 @@ Write-Host "[$(Get-Date -Format t)] INFO: Deployment is complete. Deployment tim
 Write-Host
 
 Stop-Transcript
-
-Wait-Debugger

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1112,7 +1112,7 @@ foreach ($resource in $resources) {
 
                 try {
 
-                    az k8s-extension delete --name "flux" --cluster-name $resourceName --resource-group $Env:resourceGroup --cluster-type $ClusterType --force
+                    az k8s-extension delete --name "flux" --cluster-name $resourceName --resource-group $Env:resourceGroup --cluster-type $ClusterType --force --yes
 
                     az k8s-extension create --name "flux" --extension-type "microsoft.flux" --cluster-name $resourceName --resource-group $Env:resourceGroup --cluster-type $ClusterType --output json | ConvertFrom-Json -OutVariable extension
 


### PR DESCRIPTION
- Changed to leverage Azure CLI for installing the Flux extension due to an [issue](https://github.com/Azure/azure-powershell/issues/22455) with the New-AzKubernetesExtension command on AKS clusters
- Increased retry period for Arc-enabled clusters
- Removed DevToolsInstallationJob log collection due to issue with connection to background job (can be re-added later if needed, requires troubleshooting)