### PR TITLE
Redirect error stream to stdout

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1019,7 +1019,7 @@ foreach ($VM in $VMNames) {
 
         kubectl get svc
         Connect-AksEdgeArc -JsonConfigFilePath $deploymentPath
-    } | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\ArcConnectivity.log")
+    } 2>&1 | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\ArcConnectivity.log")
 }
 
 #####################################################################
@@ -1332,10 +1332,10 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                 --timeout 10m `
                 --namespace $namespace `
                 --only-show-errors `
-            | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                2>&1 | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
 
             do {
-                $configStatus = $(az k8s-configuration flux show --name $configName --cluster-name $clusterName --cluster-type $type --resource-group $resourceGroup -o json) | convertFrom-JSON
+                $configStatus = $(az k8s-configuration flux show --name $configName --cluster-name $clusterName --cluster-type $type --resource-group $resourceGroup -o json 2>$null) | convertFrom-JSON
                 if ($configStatus.ComplianceState -eq "Compliant") {
                     Write-Host "[$(Get-Date -Format t)] INFO: GitOps configuration $configName is ready on $clusterName" -ForegroundColor DarkGreen | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
                 }
@@ -1345,7 +1345,7 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries) {
                         Start-Sleep -Seconds 20
-                        $configStatus = $(az k8s-configuration flux show --name $configName --cluster-name $clusterName --cluster-type $type --resource-group $resourceGroup -o json) | convertFrom-JSON
+                        $configStatus = $(az k8s-configuration flux show --name $configName --cluster-name $clusterName --cluster-type $type --resource-group $resourceGroup -o json 2>$null) | convertFrom-JSON
                         if ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -lt $maxRetries) {
                             $retryCount++
                             Write-Host "[$(Get-Date -Format t)] INFO: Attempting to re-install $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
@@ -1358,7 +1358,7 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                             --force `
                             --yes `
                             --only-show-errors `
-                            | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                            2>&1 | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
 
                             Start-Sleep -Seconds 10
                             Write-Host "[$(Get-Date -Format t)] INFO: Re-creating $configName on $clusterName" -ForegroundColor Gray | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
@@ -1375,7 +1375,7 @@ foreach ($cluster in $AgConfig.SiteConfig.GetEnumerator()) {
                             --timeout 30m `
                             --namespace $namespace `
                             --only-show-errors `
-                        | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
+                            2>&1 | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\GitOps-$clusterName.log")
                         }
                     }
                     elseif ($configStatus.ComplianceState -eq "Non-compliant" -and $retryCount -eq $maxRetries) {


### PR DESCRIPTION
Some calls to Azure CLI returns this warning after version 2.51.0 was released:

`UserWarning: You are using cryptography on a 32-bit Python on a 64-bit Windows Operating System.
Cryptography will be significantly faster if you switch to using a 64-bit Python.`

Since this warning is going into the error stream in PowerShell, it is not redirected to the log-files by Out-File as intended - and is rather displayed in the console and logged to AgLogonScript.log.

This PR will redirect the error stream from the offending Azure CLI calls to standard output.

Fixes https://github.com/microsoft/azure_arc/issues/2032