### PR TITLE
Updated VM image for GCP Linux-scenario

### DIFF
--- a/azure_arc_servers_jumpstart/gcp/ubuntu/terraform/main.tf
+++ b/azure_arc_servers_jumpstart/gcp/ubuntu/terraform/main.tf
@@ -12,7 +12,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1804-lts"
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
     }
   }
 


### PR DESCRIPTION
- Updated VM image for GCP Linux-scenario to `ubuntu-2204-lts`
- Tested deployment successfully
- Fixes #1557