### PR TITLE
Modify AKS EE Arc onboarding to allow Managed Prometheus Microsoft.AzureMonitor.Containers.Metrics Arc extension deployment

### DIFF
--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single/arm_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single/arm_template/artifacts/LogonScript.ps1
@@ -235,11 +235,25 @@ $clusterId = $(kubectl get configmap -n aksedge aksedge -o jsonpath="{.data.clus
 
 $guid = ([System.Guid]::NewGuid()).ToString().subString(0,5).ToLower()
 $Env:arcClusterName = "$Env:resourceGroup-$guid"
-az connectedk8s connect --name $Env:arcClusterName `
+
+
+if ($env:kubernetesDistribution -eq "k8s") {
+    az connectedk8s connect --name $Env:arcClusterName `
     --resource-group $Env:resourceGroup `
     --location $env:location `
+    --distribution aks_edge_k8s `
     --tags "Project=jumpstart_azure_arc_k8s" "ClusterId=$clusterId" `
     --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
+} else {
+    az connectedk8s connect --name $Env:arcClusterName `
+    --resource-group $Env:resourceGroup `
+    --location $env:location `
+    --distribution aks_edge_k3s `
+    --tags "Project=jumpstart_azure_arc_k8s" "ClusterId=$clusterId" `
+    --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
+}
+
+
 
 Write-Host "`n"
 Write-Host "Create Azure Monitor for containers Kubernetes extension instance"

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/artifacts/LogonScript.ps1
@@ -235,11 +235,21 @@ $clusterId = $(kubectl get configmap -n aksedge aksedge -o jsonpath="{.data.clus
 
 $guid = ([System.Guid]::NewGuid()).ToString().subString(0,5).ToLower()
 $Env:arcClusterName = "$Env:resourceGroup-$guid"
-az connectedk8s connect --name $Env:arcClusterName `
+if ($env:kubernetesDistribution -eq "k8s") {
+    az connectedk8s connect --name $Env:arcClusterName `
     --resource-group $Env:resourceGroup `
     --location $env:location `
+    --distribution aks_edge_k8s `
     --tags "Project=jumpstart_azure_arc_k8s" "ClusterId=$clusterId" `
     --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
+} else {
+    az connectedk8s connect --name $Env:arcClusterName `
+    --resource-group $Env:resourceGroup `
+    --location $env:location `
+    --distribution aks_edge_k3s `
+    --tags "Project=jumpstart_azure_arc_k8s" "ClusterId=$clusterId" `
+    --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
+}
 
 Write-Host "`n"
 Write-Host "Create Azure Monitor for containers Kubernetes extension instance"

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/azuredeploy.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/azuredeploy.json
@@ -97,14 +97,14 @@
             "metadata": {
                 "description": "Target GitHub account"
             },
-            "defaultValue": "microsoft"
+            "defaultValue": "lanicolas"
         },
         "githubBranch": {
             "type": "string",
             "metadata": {
                 "description": "Target GitHub branch"
             },
-            "defaultValue": "main"
+            "defaultValue": "eeonboard"
         },
         "virtualNetworkName": {
             "type": "string",

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/azuredeploy.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/azuredeploy.json
@@ -97,14 +97,14 @@
             "metadata": {
                 "description": "Target GitHub account"
             },
-            "defaultValue": "lanicolas"
+            "defaultValue": "microsoft"
         },
         "githubBranch": {
             "type": "string",
             "metadata": {
                 "description": "Target GitHub branch"
             },
-            "defaultValue": "eeonboard"
+            "defaultValue": "main"
         },
         "virtualNetworkName": {
             "type": "string",


### PR DESCRIPTION
AKS EE Arc onboarding is changed specifying Kubernetes distribution [--distribution {aks, aks_edge_k3s, aks_edge_k8s, aks_engine, aks_management, aks_workload, canonical, capz, eks, generic, gke, k3s, karbon, kind, minikube, openshift, rancher_rke, tkg}] to allow the deployment of Azure Monitor extension used with Azure Managed Prometheus. This is linked to issue: 

https://github.com/Azure/AKS-Edge/issues/138#issuecomment-1730530872