### PR TITLE
Azure Arc-enabled Kubernetes - changed secure string variable type

### DIFF
--- a/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/variable.tf
+++ b/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/variable.tf
@@ -280,6 +280,7 @@ variable "rbac_aad_server_app_secret" {
   type        = string
   description = "(Optional) The Server Secret of an Azure Active Directory Application. Changing this forces a new resource to be created."
   default     = null
+  sensitive   = true
 }
 
 variable "rbac_aad_tenant_id" {
@@ -422,6 +423,7 @@ variable "user-name-vm" {
 variable "user-password-vm" {
   description = "(Required) Password of Virtual Machine"
   default="Password1234!"
+  sensitive = true
 }
 
 variable "password_authentication-vm" {

--- a/azure_arc_k8s_jumpstart/alibaba/terraform/module/variables.tf
+++ b/azure_arc_k8s_jumpstart/alibaba/terraform/module/variables.tf
@@ -114,6 +114,7 @@ variable "ecs_password" {
   description = "The password of worker nodes."
   type        = string
   default     = "Abc12345"
+  sensitive   = true
 }
 
 variable "worker_number" {

--- a/azure_arc_k8s_jumpstart/eks/terraform/variables.tf
+++ b/azure_arc_k8s_jumpstart/eks/terraform/variables.tf
@@ -6,6 +6,7 @@ variable "AWS_ACCESS_KEY_ID" {
 variable "AWS_SECRET_ACCESS_KEY" {
   description = "Your AWS Secret Key"
   type        = string
+  sensitive   = true
 }
 
 variable "AWS_REGION" {

--- a/azure_arc_k8s_jumpstart/gke/terraform/variables.tf
+++ b/azure_arc_k8s_jumpstart/gke/terraform/variables.tf
@@ -23,6 +23,7 @@ variable "servicePrincipalAppId" {
 variable "servicePrincipalSecret" {
   description = "Azure service principal App Password"
   type        = string
+  sensitive   = true
 }
 
 variable "servicePrincipalTenantId" {
@@ -61,6 +62,7 @@ variable "admin_username" {
 variable "admin_password" {
   description = "GKE control plane administrator username"
   type        = string
+  sensitive   = true
 }
 
 variable "gke_cluster_node_count" {

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/azuredeploy.json
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/azuredeploy.json
@@ -29,7 +29,7 @@
             }
         },
         "password": {
-            "type": "string",
+            "type": "securestring",
             "metadata": {
                 "description": "Unique SPN password"
             }

--- a/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/variables.tf
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/variables.tf
@@ -13,6 +13,7 @@ variable "client_id" {
 }
 
 variable "client_secret" {
+  sensitive = true
 }
 
 variable "tenant_id" {
@@ -23,6 +24,7 @@ variable "vsphere_user" {
 }
 
 variable "vsphere_password" {
+  sensitive = true
 }
 
 variable "vsphere_server" {
@@ -115,4 +117,5 @@ variable "vm_dns" {
 variable "admin_user" {
 }
 variable "admin_password" {
+  sensitive = true
 }


### PR DESCRIPTION
Updated the Azure Arc-enabled Kubernetes to have all secrets and passwords variables as secure string.