### PR TITLE
Modify --password switch in az login to avoid failures when password starts with hyphen

### DIFF
--- a/azure_arc_app_services_jumpstart/aks/ARM/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/ARM/artifacts/AppServicesLogonScript.ps1
@@ -3,7 +3,7 @@ Start-Transcript -Path C:\Temp\AppServicesLogonScript.log
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Deployment environment variables
 $Env:TempDir = "C:\Temp"

--- a/azure_arc_app_services_jumpstart/aks/ARM/artifacts/ContainerAppsLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/aks/ARM/artifacts/ContainerAppsLogonScript.ps1
@@ -3,7 +3,7 @@ Start-Transcript -Path C:\Temp\ContainerAppsLogonScript.log
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Deployment environment variables
 $Env:TempDir = "C:\Temp"

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/AppServicesLogonScript.ps1
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/AppServicesLogonScript.ps1
@@ -3,7 +3,7 @@ Start-Transcript -Path C:\Temp\AppServicesLogonScript.log
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Deployment environment variables
 $Env:TempDir = "C:\Temp"

--- a/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_app_services_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -54,7 +54,7 @@ sudo -u $adminUsername az extension add --name k8s-extension -y
 echo ""
 
 echo "Log in to Azure"
-sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
+sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password=$SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 subscriptionId=$(sudo -u $adminUsername az account show --query id --output tsv)
 export AZURE_RESOURCE_GROUP=$(sudo -u $adminUsername az resource list --query "[?name=='$stagingStorageAccountName']".[resourceGroup] --resource-type "Microsoft.Storage/storageAccounts" -o tsv)
 sudo -u $adminUsername az -v

--- a/azure_arc_data_jumpstart/aks/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/ARM/artifacts/DataServicesLogonScript.ps1
@@ -7,7 +7,7 @@ $connectedClusterName = "Arc-DataSvc-AKS"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/DataServicesLogonScript.ps1
@@ -13,7 +13,7 @@ $secondaryDcName= "jumpstart-secondary-dc"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/DataServicesLogonScript.ps1
@@ -8,7 +8,7 @@ $connectedClusterName = "Arc-DataSvc-AKS"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/aro/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aro/ARM/artifacts/DataServicesLogonScript.ps1
@@ -7,7 +7,7 @@ $connectedClusterName = "Arc-Data-ARO"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/DataServicesLogonScript.ps1
@@ -12,7 +12,7 @@ $psCred = New-Object System.Management.Automation.PSCredential($Env:spnClientId 
 Connect-AzAccount -Credential $psCred -TenantId $Env:spnTenantId -ServicePrincipal
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
+++ b/azure_arc_data_jumpstart/cluster_api/capi_azure/ARM/artifacts/installCAPI.sh
@@ -49,7 +49,7 @@ sudo -u $adminUsername az extension add --name k8s-configuration
 sudo -u $adminUsername az extension add --name k8s-extension
 
 echo "Log in to Azure"
-sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
+sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password=$SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 subscriptionId=$(sudo -u $adminUsername az account show --query id --output tsv)
 export AZURE_RESOURCE_GROUP=$(sudo -u $adminUsername az resource list --query "[?name=='$stagingStorageAccountName']".[resourceGroup] --resource-type "Microsoft.Storage/storageAccounts" -o tsv)
 az -v

--- a/azure_arc_data_jumpstart/eks/terraform/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/eks/terraform/artifacts/DataServicesLogonScript.ps1
@@ -7,7 +7,7 @@ $connectedClusterName = "Arc-Data-EKS"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
@@ -12,7 +12,7 @@ $psCred = New-Object System.Management.Automation.PSCredential($env:spnClientId 
 Connect-AzAccount -Credential $psCred -TenantId $env:spnTenantId -ServicePrincipal
 
 # Login as service principal
-az login --service-principal --username $env:spnClientId --password $env:spnClientSecret --tenant $env:spnTenantId
+az login --service-principal --username $env:spnClientId --password=$Env:spnClientSecret --tenant $env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/DataServicesLogonScript.ps1
@@ -11,7 +11,7 @@ $psCred = New-Object System.Management.Automation.PSCredential($Env:spnClientId 
 Connect-AzAccount -Credential $psCred -TenantId $Env:spnTenantId -ServicePrincipal
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/installKubeadm.sh
+++ b/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/installKubeadm.sh
@@ -52,7 +52,7 @@ sudo -u $adminUsername az extension add --name k8s-configuration --yes
 sudo -u $adminUsername az extension add --name k8s-extension --yes
 
 echo "Log in to Azure"
-sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
+sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password=$SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 subscriptionId=$(sudo -u $adminUsername az account show --query id --output tsv)
 export AZURE_RESOURCE_GROUP=$(sudo -u $adminUsername az resource list --query "[?name=='$stagingStorageAccountName']".[resourceGroup] --resource-type "Microsoft.Storage/storageAccounts" -o tsv)
 az -v

--- a/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/installKubeadmWorker.sh
+++ b/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/installKubeadmWorker.sh
@@ -42,7 +42,7 @@ sudo -u $adminUsername az extension add --name k8s-configuration --yes
 sudo -u $adminUsername az extension add --name k8s-extension --yes
 
 echo "Log in to Azure"
-sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
+sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password=$SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 subscriptionId=$(sudo -u $adminUsername az account show --query id --output tsv)
 export AZURE_RESOURCE_GROUP=$(sudo -u $adminUsername az resource list --query "[?name=='$stagingStorageAccountName']".[resourceGroup] --resource-type "Microsoft.Storage/storageAccounts" -o tsv)
 az -v

--- a/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
@@ -11,7 +11,7 @@ $psCred = New-Object System.Management.Automation.PSCredential($Env:spnClientId 
 Connect-AzAccount -Credential $psCred -TenantId $Env:spnTenantId -ServicePrincipal
 
 # Login as service principal
-az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Installing Azure CLI arcdata extension
 Write-Host "`n"

--- a/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/install_microk8s.sh
+++ b/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/install_microk8s.sh
@@ -33,7 +33,7 @@ echo "##########################################################################
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 echo "Log in to Azure"
-sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
+sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password=$SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 subscriptionId=$(sudo -u $adminUsername az account show --query id --output tsv)
 resourceGroup=$(sudo -u $adminUsername az resource list --query "[?name=='$stagingStorageAccountName']".[resourceGroup] --resource-type "Microsoft.Storage/storageAccounts" -o tsv)
 az -v

--- a/azure_arc_k8s_jumpstart/aks/arm_template/scripts/az_connect_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks/arm_template/scripts/az_connect_aks.sh
@@ -11,7 +11,7 @@ export arcClusterName='<The name of your k8s cluster as it will be shown in Azur
 
 # Log in to Azure
 echo "Log in to Azure with Service Principle"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Registering Azure Arc providers
 echo "Registering Azure Arc providers"

--- a/azure_arc_k8s_jumpstart/aks/azure_monitor/aks_monitor_onboarding.ps1
+++ b/azure_arc_k8s_jumpstart/aks/azure_monitor/aks_monitor_onboarding.ps1
@@ -12,7 +12,7 @@ Write-Output  "Downloading the Azure Monitor onboarding script"
 Invoke-WebRequest https://aka.ms/enable-monitoring-powershell-script -OutFile enable-monitoring.ps1
 
 Write-Output "Onboarding the Azure Arc-enabled Kubernetes cluster to Azure Monitor for containers"
-az login --service-principal --username $env:appId --password $env:password --tenant $env:tenantId
+az login --service-principal --username $env:appId --password=$env:password --tenant $env:tenantId
 az aks get-credentials --name $env:arcClusterName --resource-group $env:resourceGroup --overwrite-existing
 $env:azureArcClusterResourceId = $(az resource show --resource-group $env:resourceGroup --name $env:arcClusterName --resource-type "Microsoft.Kubernetes/connectedClusters" --query id -o tsv)
 $env:kubeContext = kubectl config current-context

--- a/azure_arc_k8s_jumpstart/aks/azure_monitor/aks_monitor_onboarding.sh
+++ b/azure_arc_k8s_jumpstart/aks/azure_monitor/aks_monitor_onboarding.sh
@@ -14,7 +14,7 @@ echo "Downloading the Azure Monitor onboarding script"
 curl -o enable-monitoring.sh -L https://aka.ms/enable-monitoring-bash-script
 
 echo "Onboarding the Azure Arc-enabled Kubernetes cluster to Azure Monitor for containers"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --overwrite-existing
 export azureArcClusterResourceId=$(az resource show --resource-group $resourceGroup --name $arcClusterName --resource-type "Microsoft.Kubernetes/connectedClusters" --query id -o tsv)
 export kubeContext="$(kubectl config current-context)"

--- a/azure_arc_k8s_jumpstart/aks/azure_policy/aks_policy_onboarding.sh
+++ b/azure_arc_k8s_jumpstart/aks/azure_policy/aks_policy_onboarding.sh
@@ -10,7 +10,7 @@ export resourceGroup='<Azure resource group name>'
 export arcClusterName='<The name of your k8s cluster as it will be shown in Azure Arc>'
 
 echo "Log in to Azure with Service Principal & Getting Connected Cluster Azure Resource ID"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --overwrite-existing
 export clusterId="$(az resource show --resource-group $resourceGroup --name $arcClusterName --resource-type "Microsoft.Kubernetes/connectedClusters" --query id)"
 export clusterId="$(echo "$clusterId" | sed -e 's/^"//' -e 's/"$//')" 

--- a/azure_arc_k8s_jumpstart/aks/gitops/basic/az_k8sconfig_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks/gitops/basic/az_k8sconfig_aks.sh
@@ -13,7 +13,7 @@ export namespace='hello-arc'
 
 # Getting AKS credentials
 echo "Log in to Azure with Service Principal & Getting AKS credentials (kubeconfig)"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --overwrite-existing
 
 # Create a namespace for your app & ingress resources

--- a/azure_arc_k8s_jumpstart/aks/gitops/helm/az_k8sconfig_helm_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks/gitops/helm/az_k8sconfig_helm_aks.sh
@@ -14,7 +14,7 @@ export namespace='hello-arc'
 
 # Getting AKS credentials
 echo "Log in to Azure with Service Principal & Getting AKS credentials (kubeconfig)"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --overwrite-existing
 
 # Create GitOps config for NGINX Ingress Controller

--- a/azure_arc_k8s_jumpstart/aks/gitops/helm/az_k8sconfig_helm_cleanup.sh
+++ b/azure_arc_k8s_jumpstart/aks/gitops/helm/az_k8sconfig_helm_cleanup.sh
@@ -13,7 +13,7 @@ export namespace='hello-arc'
 
 # Login to Azure using the service principal name
 echo "Log in to Azure with Service Principal & Getting AKS credentials (kubeconfig)"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --overwrite-existing
 
 # Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster

--- a/azure_arc_k8s_jumpstart/aks/terraform/scripts/az_connect_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks/terraform/scripts/az_connect_aks.sh
@@ -11,7 +11,7 @@ export arcClusterName='<The name of your k8s cluster as it will be shown in Azur
 
 # Log in to Azure
 echo "Log in to Azure with Service Principle"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Registering Azure Arc providers
 echo "Registering Azure Arc providers"

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/LogonScript.ps1
@@ -39,7 +39,7 @@ if (-not $($cliDir.Parent.Attributes.HasFlag([System.IO.FileAttributes]::Hidden)
 $Env:AZURE_CONFIG_DIR = $cliDir.FullName
 
 Write-Host "INFO: Logging into Az CLI using the service principal and secret provided at deployment" -ForegroundColor Gray
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 $AzCLIExtensions = @(
     'k8s-extension',

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/LogonScript.ps1
@@ -43,7 +43,7 @@ if (-not $($cliDir.Parent.Attributes.HasFlag([System.IO.FileAttributes]::Hidden)
 $Env:AZURE_CONFIG_DIR = $cliDir.FullName
 
 Write-Host "INFO: Logging into Az CLI using the service principal and secret provided at deployment" -ForegroundColor Gray
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 $AzCLIExtensions = @(
     'k8s-extension',

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single/arm_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single/arm_template/artifacts/LogonScript.ps1
@@ -198,7 +198,7 @@ Write-Host "`n"
 az -v
 
 # Login as service principal
-az login --service-principal --username $Env:appId --password $Env:password --tenant $Env:tenantId
+az login --service-principal --username $Env:appId --password=$Env:password --tenant $Env:tenantId
 
 # Set default subscription to run commands against
 # "subscriptionId" value comes from clientVM.json ARM template, based on which 

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_akri/arm_template/artifacts/LogonScript.ps1
@@ -197,7 +197,7 @@ Write-Host "`n"
 az -v
 
 # Login as service principal
-az login --service-principal --username $Env:appId --password $Env:password --tenant $Env:tenantId
+az login --service-principal --username $Env:appId --password=$Env:password --tenant $Env:tenantId
 
 # Set default subscription to run commands against
 # "subscriptionId" value comes from clientVM.json ARM template, based on which 

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_vi/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_single_vi/artifacts/LogonScript.ps1
@@ -83,7 +83,7 @@ Write-Host "`n"
 az -v
 
 # Login as service principal
-az login --service-principal --username $Env:appId --password $Env:password --tenant $Env:tenantId
+az login --service-principal --username $Env:appId --password=$Env:password --tenant $Env:tenantId
 
 # Set default subscription to run commands against
 # "subscriptionId" value comes from clientVM.json ARM template, based on which 

--- a/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/scripts/helm/az_k8sconfig_helm_aks.sh
+++ b/azure_arc_k8s_jumpstart/aks_iot_edge/terraform/scripts/helm/az_k8sconfig_helm_aks.sh
@@ -10,7 +10,7 @@ export arcClusterName='<The name of your k8s cluster as it will be shown in Azur
 
 # Getting AKS credentials
 echo "Log in to Azure with Service Principal & Getting AKS credentials (kubeconfig)"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az aks get-credentials --name $arcClusterName --resource-group $resourceGroup --overwrite-existing
 az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"
 

--- a/azure_arc_k8s_jumpstart/aks_stack_hci/gitops/basic/az_k8sconfig_aks_hci.ps1
+++ b/azure_arc_k8s_jumpstart/aks_stack_hci/gitops/basic/az_k8sconfig_aks_hci.ps1
@@ -12,7 +12,7 @@ $subscriptionId ='<Your subscription ID>'
 
 # Connect to Azure
 Write-Host "Log in to Azure with Service Principal & Getting AKS credentials (kubeconfig)"
-az login --service-principal --username $appId --password $password --tenant $tenant
+az login --service-principal --username $appId --password=$password --tenant $tenant
 az account set --subscription $subscriptionId
 
 #Configure Extension install

--- a/azure_arc_k8s_jumpstart/aks_stack_hci/gitops/helm/az_k8sconfig_helm_aks.ps1
+++ b/azure_arc_k8s_jumpstart/aks_stack_hci/gitops/helm/az_k8sconfig_helm_aks.ps1
@@ -11,7 +11,7 @@ $subscriptionId ='<Your subscription ID>'
 
 # Login to Azure & get AKS on HCI credentials
 Write-Host "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az account set --subscription $subscriptionId
 
 #Configure Extension install

--- a/azure_arc_k8s_jumpstart/aks_stack_hci/gitops/helm/az_k8sconfig_helm_cleanup.ps1
+++ b/azure_arc_k8s_jumpstart/aks_stack_hci/gitops/helm/az_k8sconfig_helm_cleanup.ps1
@@ -11,7 +11,7 @@ $subscriptionId ='<Your subscription ID>'
 
 # Login to Azure & get AKS on HCI credentials
 Write-Host "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az account set --subscription $subscriptionId
 Write-Host "Getting AKS on HCI credentials (kubeconfig)"
 Get-AksHciCredential -Name $ClusterName 

--- a/azure_arc_k8s_jumpstart/aks_stack_hci/monitor_extension/azure_monitor_k8s_extension.ps1
+++ b/azure_arc_k8s_jumpstart/aks_stack_hci/monitor_extension/azure_monitor_k8s_extension.ps1
@@ -26,7 +26,7 @@ az extension add --name "k8s-extension"
 az extension update --name "k8s-extension"
 
 # Login to Az CLI using the service principal
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Create monitor k8s extension instance
 az k8s-extension create --name $k8sExtensionName --cluster-name $arcClusterName --resource-group $resourceGroup --cluster-ty

--- a/azure_arc_k8s_jumpstart/aro/arm_template/scripts/az_connect_aro.sh
+++ b/azure_arc_k8s_jumpstart/aro/arm_template/scripts/az_connect_aro.sh
@@ -17,7 +17,7 @@ echo ""
 
 # Getting ARO cluster credentials
 echo "Log in to Azure with Service Principle & Getting ARO credentials (kubeconfig)"
-az login --service-principal --username $AZURE_CLIENT_ID --password $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+az login --service-principal --username $AZURE_CLIENT_ID --password=$AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
 echo ""
 kubcepass=$(az aro list-credentials --name $AZURE_ARC_CLUSTER_RESOURCE_NAME -g $AZURE_RESOURCE_GROUP --query kubeadminPassword -o tsv)
 echo ""

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_azure/artifacts/installCAPI.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_azure/artifacts/installCAPI.sh
@@ -61,7 +61,7 @@ echo ""
   echo ""
 
   echo "Log in to Azure"
-  sudo -u $USER az login --service-principal --username $AZURE_CLIENT_ID --password $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+  sudo -u $USER az login --service-principal --username $AZURE_CLIENT_ID --password=$AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
   az -v
   echo ""
 

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_azure/installCAPI.sh
@@ -63,7 +63,7 @@ echo ""
   echo ""
 
   echo "Log in to Azure"
-  sudo -u $USER az login --service-principal --username $AZURE_CLIENT_ID --password $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
+  sudo -u $USER az login --service-principal --username $AZURE_CLIENT_ID --password=$AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID
   az -v
   echo ""
 

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_defender_extension/azure_defender_k8s_extension.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_defender_extension/azure_defender_k8s_extension.sh
@@ -54,7 +54,7 @@ fi
 echo ""
 
 echo "Login to Az CLI using the service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 echo "Create Azure Defender Kubernetes extension instance"
 az k8s-extension create --name $k8sExtensionName --cluster-name $arcClusterName --resource-group $resourceGroup --cluster-type connectedClusters --extension-type microsoft.azuredefender.kubernetes

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_keyvault_extension/capi_keyvault_k8s_extension.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_keyvault_extension/capi_keyvault_k8s_extension.sh
@@ -26,7 +26,7 @@ echo "Clear cached helm Azure Arc Helm Charts"
 rm -rf ~/.azure/AzureArcCharts
 
 echo "Login to Az CLI using the service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 echo "Checking if you have up-to-date Azure Arc Az CLI 'connectedk8s' extension..."
 az extension show --name "connectedk8s" &> extension_output

--- a/azure_arc_k8s_jumpstart/cluster_api/capi_osm_extension/capi_osm_extension.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/capi_osm_extension/capi_osm_extension.sh
@@ -58,7 +58,7 @@ fi
 echo ""
 
 echo "Login to Az CLI using the service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 echo "Create OSM Kubernetes extension instance"
 az k8s-extension create --cluster-name $arcClusterName --resource-group $resourceGroup --cluster-type connectedClusters --extension-type Microsoft.openservicemesh --scope cluster --name $k8sOSMExtensionName

--- a/azure_arc_k8s_jumpstart/cluster_api/gitops/basic/az_k8sconfig_capi.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/gitops/basic/az_k8sconfig_capi.sh
@@ -28,7 +28,7 @@ az extension add --name k8s-configuration
 
 # Login to Azure
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Registering Azure Arc providers
 echo "Registering Azure Arc providers"

--- a/azure_arc_k8s_jumpstart/cluster_api/gitops/helm/az_k8sconfig_helm_capi.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/gitops/helm/az_k8sconfig_helm_capi.sh
@@ -22,7 +22,7 @@ az extension add --name k8s-configuration
 
 # Login to Azure
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Registering Azure Arc providers
 echo "Registering Azure Arc providers"

--- a/azure_arc_k8s_jumpstart/cluster_api/gitops/helm/az_k8sconfig_helm_cleanup.sh
+++ b/azure_arc_k8s_jumpstart/cluster_api/gitops/helm/az_k8sconfig_helm_cleanup.sh
@@ -13,7 +13,7 @@ export namespace='hello-arc'
 
 # Login to Azure using the service principal name
 echo "Log in to Azure with Service Principal & Getting credentials (kubeconfig)"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster
 echo "Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster"

--- a/azure_arc_k8s_jumpstart/gke/azure_policy/gke_policy_onboarding.sh
+++ b/azure_arc_k8s_jumpstart/gke/azure_policy/gke_policy_onboarding.sh
@@ -38,7 +38,7 @@ helm install hello-arc stable/nginx-ingress \
     --set defaultBackend.nodeSelector."beta\.kubernetes\.io/os"=linux
 
 echo "Log in to Azure with service principal & Getting Connected Cluster Azure resource ID"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 export clusterId="$(az resource show --resource-group $resourceGroup --name $arcClusterName --resource-type "Microsoft.Kubernetes/connectedClusters" --query id)"
 export clusterId="$(echo "$clusterId" | sed -e 's/^"//' -e 's/"$//')" 
 

--- a/azure_arc_k8s_jumpstart/gke/gitops/basic/az_k8sconfig_gke.sh
+++ b/azure_arc_k8s_jumpstart/gke/gitops/basic/az_k8sconfig_gke.sh
@@ -21,7 +21,7 @@ curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
 # Login to Azure
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Create a namespace for your app & ingress resources
 kubectl create ns $namespace

--- a/azure_arc_k8s_jumpstart/gke/gitops/helm/az_k8sconfig_helm_cleanup.sh
+++ b/azure_arc_k8s_jumpstart/gke/gitops/helm/az_k8sconfig_helm_cleanup.sh
@@ -34,7 +34,7 @@ echo ""
 
 # Login to Azure using the service principal
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster
 echo "Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster"

--- a/azure_arc_k8s_jumpstart/gke/gitops/helm/az_k8sconfig_helm_gke.sh
+++ b/azure_arc_k8s_jumpstart/gke/gitops/helm/az_k8sconfig_helm_gke.sh
@@ -36,7 +36,7 @@ echo ""
 
 # Login to Azure
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Create GitOps config for NGINX Ingress Controller
 echo "Creating GitOps config for NGINX Ingress Controller"

--- a/azure_arc_k8s_jumpstart/gke/gke_monitor/gke_monitor_onboarding.sh
+++ b/azure_arc_k8s_jumpstart/gke/gke_monitor/gke_monitor_onboarding.sh
@@ -32,7 +32,7 @@ echo "Downloading the Azure Monitor onboarding script"
 curl -o enable-monitoring.sh -L https://aka.ms/enable-monitoring-bash-script
 
 echo "Onboarding the Azure Arc-enabled Kubernetes cluster to Azure Monitor for containers"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 export azureArcClusterResourceId=$(az resource show --resource-group $resourceGroup --name $arcClusterName --resource-type "Microsoft.Kubernetes/connectedClusters" --query id -o tsv)
 export kubeContext="$(kubectl config current-context)"
 bash enable-monitoring.sh --resource-id $azureArcClusterResourceId --client-id $appId --client-secret $password --tenant-id $tenantId --kube-context $kubeContext

--- a/azure_arc_k8s_jumpstart/gke/gke_monitor_extension/azure_monitor_k8s_extension.sh
+++ b/azure_arc_k8s_jumpstart/gke/gke_monitor_extension/azure_monitor_k8s_extension.sh
@@ -54,7 +54,7 @@ fi
 echo ""
 
 echo "Login to Az CLI using the service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 echo "Create monitor k8s extension instance"
 az k8s-extension create --name $k8sExtensionName --cluster-name $arcClusterName --resource-group $resourceGroup --cluster-type connectedClusters --extension-type Microsoft.AzureMonitor.Containers

--- a/azure_arc_k8s_jumpstart/gke/terraform/scripts/az_connect_gke.sh
+++ b/azure_arc_k8s_jumpstart/gke/terraform/scripts/az_connect_gke.sh
@@ -46,7 +46,7 @@ fi
 echo ""
 
 echo "Log in to Azure using service principal"
-az login --service-principal --username $servicePrincipalAppId --password $servicePrincipalSecret --tenant $servicePrincipalTenantId
+az login --service-principal --username $servicePrincipalAppId --password=$servicePrincipalSecret --tenant $servicePrincipalTenantId
 
 echo "Registering Azure Arc providers"
 az provider register --namespace Microsoft.Kubernetes --wait

--- a/azure_arc_k8s_jumpstart/kind/gitops/helm/az_k8sconfig_helm_cleanup_kind.sh
+++ b/azure_arc_k8s_jumpstart/kind/gitops/helm/az_k8sconfig_helm_cleanup_kind.sh
@@ -11,7 +11,7 @@ export tenantId='<Your Azure tenant ID>'
 
 # Logging in to Azure using service principal
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster
 echo "Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster"

--- a/azure_arc_k8s_jumpstart/kind/gitops/helm/az_k8sconfig_helm_kind.sh
+++ b/azure_arc_k8s_jumpstart/kind/gitops/helm/az_k8sconfig_helm_kind.sh
@@ -12,7 +12,7 @@ export appClonedRepo='<The URL for the "Hello Arc" cloned GitHub repository>'
 
 # Logging in to Azure using service principal
 echo "Log in to Azure with Service Principal & Getting AKS credentials (kubeconfig)"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Create Namespace-level GitOps-Config for deploying the "Hello Arc" application
 echo "Create Namespace-level GitOps-Config for deploying the 'Hello Arc' application"

--- a/azure_arc_k8s_jumpstart/microk8s/azure_monitor/microk8s_monitor_onboarding.ps1
+++ b/azure_arc_k8s_jumpstart/microk8s/azure_monitor/microk8s_monitor_onboarding.ps1
@@ -12,7 +12,7 @@ Write-Output  "Downloading the Azure Monitor onboarding script"
 Invoke-WebRequest https://aka.ms/enable-monitoring-powershell-script -OutFile enable-monitoring.ps1
 
 Write-Output "Onboarding the Azure Arc-enabled Kubernetes cluster to Azure Monitor for containers"
-az login --service-principal --username $env:appId --password $env:password --tenant $env:tenantId
+az login --service-principal --username $env:appId --password=$env:password --tenant $env:tenantId
 
 if(!(Test-Path -path "$env:userprofile/.kube"))  
 { 

--- a/azure_arc_k8s_jumpstart/microk8s/azure_monitor/microk8s_monitor_onboarding.sh
+++ b/azure_arc_k8s_jumpstart/microk8s/azure_monitor/microk8s_monitor_onboarding.sh
@@ -14,7 +14,7 @@ echo "Downloading the Azure Monitor onboarding script"
 curl -o enable-monitoring.sh -L https://aka.ms/enable-monitoring-bash-script
 
 echo "Onboarding the Azure Arc-enabled Kubernetes cluster to Azure Monitor for containers"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 mkdir -p ~/.kube
 microk8s config > ~/.kube/config
 export azureArcClusterResourceId=$(az resource show --resource-group $resourceGroup --name $arcClusterName --resource-type "Microsoft.Kubernetes/connectedClusters" --query id -o tsv)

--- a/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_cleanup_microk8s.sh
+++ b/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_cleanup_microk8s.sh
@@ -11,7 +11,7 @@ export arcClusterName='<Your Arc cluster name>'
 
 # Logging in to Azure using service principal
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster
 echo "Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster"

--- a/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_cleanup_microk8s_windows.ps1
+++ b/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_cleanup_microk8s_windows.ps1
@@ -8,7 +8,7 @@ $resourceGroup="<Your resource group name>"
 $arcClusterName="<Your Arc cluster name>"
 
 Write-Output "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 Write-Output "Deleting GitOps Configurations from Azure Arc-enabled Kubernetes cluster"
 az k8s-configuration flux delete --name config-helloarc --cluster-name $arcClusterName --resource-group $resourceGroup --cluster-type connectedClusters --force -y

--- a/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_microk8s.sh
+++ b/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_microk8s.sh
@@ -13,7 +13,7 @@ export namespace='hello-arc'
 
 # Logging in to Azure using service principal
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Create GitOps config for App Deployment
 echo "Creating GitOps config for deploying the Hello-Arc App"

--- a/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_microk8s_windows.ps1
+++ b/azure_arc_k8s_jumpstart/microk8s/gitops/helm/az_k8sconfig_helm_microk8s_windows.ps1
@@ -11,7 +11,7 @@ $namespace='hello-arc'
 
 # Logging in to Azure using service principal
 Write-Output "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Create GitOps config for App Deployment
 Write-Output "Creating GitOps config for deploying the Hello-Arc App"

--- a/azure_arc_k8s_jumpstart/multi_distributions/azure_policy/azure_policy.sh
+++ b/azure_arc_k8s_jumpstart/multi_distributions/azure_policy/azure_policy.sh
@@ -24,7 +24,7 @@ sudo -u $USER az extension add --name k8s-extension
 echo ""
 
 echo "Login to Az CLI using the service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 echo ""
 
 echo "Create the azurepolicy k8s-extension"

--- a/azure_arc_k8s_jumpstart/multi_distributions/calico_gitops/calico_k8sconfig_gitops.sh
+++ b/azure_arc_k8s_jumpstart/multi_distributions/calico_gitops/calico_k8sconfig_gitops.sh
@@ -30,7 +30,7 @@ az extension add --name k8s-configuration
 
 # Login to Azure
 echo "Log in to Azure with Service Principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Create a k8s-configuration
 echo "Create Cluster-level k8s configuration for deploying Global network set and policy"

--- a/azure_arc_k8s_jumpstart/multi_distributions/container_insights/azure_monitor_alerts.sh
+++ b/azure_arc_k8s_jumpstart/multi_distributions/container_insights/azure_monitor_alerts.sh
@@ -28,7 +28,7 @@ sudo -u $USER az extension add --name k8s-extension
 echo ""
 
 echo "Login to Az CLI using the service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 echo ""
 
 echo "Create the Log Analytics Workspace"

--- a/azure_arc_k8s_jumpstart/multi_distributions/dapr/dapr_k8s_statestore.sh
+++ b/azure_arc_k8s_jumpstart/multi_distributions/dapr/dapr_k8s_statestore.sh
@@ -13,7 +13,7 @@ export redisVMSize='c0' # Do not change!
 export redisName=secret-store-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1) # Do not change!
 
 echo "Login to Az CLI using the service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 echo "Checking if you have up-to-date Azure Arc AZ CLI 'k8s-extension' extension..."
 az extension show --name "k8s-extension" &> extension_output

--- a/azure_arc_k8s_jumpstart/pf9/pf9_az_connect_k8s.sh
+++ b/azure_arc_k8s_jumpstart/pf9/pf9_az_connect_k8s.sh
@@ -26,7 +26,7 @@ echo "Creating the Resource Group"
 az group create -l $azureRegion -n $resourceGroup
 
 echo "Log in to Azure using service principal"
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 echo "Connecting the cluster to Azure Arc"
 az connectedk8s connect --name $arcClusterName --resource-group $resourceGroup --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/installK3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/arm_template/scripts/installK3s.sh
@@ -65,7 +65,7 @@ sudo -u $adminUsername az extension add --name "k8s-configuration"
 sudo -u $adminUsername az extension add --name "k8s-extension"
 sudo -u $adminUsername az extension add --name "customlocation"
 
-sudo -u $adminUsername az login --service-principal --username $appId --password $password --tenant $tenantId
+sudo -u $adminUsername az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Onboard the cluster to Azure Arc and enabling Container Insights using Kubernetes extension
 echo ""

--- a/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/installK3s.sh
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/azure/terraform/scripts/installK3s.sh
@@ -65,7 +65,7 @@ sudo -u $adminUsername az extension add --name "k8s-configuration"
 sudo -u $adminUsername az extension add --name "k8s-extension"
 sudo -u $adminUsername az extension add --name "customlocation"
 
-sudo -u $adminUsername az login --service-principal --username $appId --password $password --tenant $tenantId
+sudo -u $adminUsername az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 # Onboard the cluster to Azure Arc and enabling Container Insights using Kubernetes extension
 echo ""

--- a/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/az_connect_k3s.sh.tmpl
+++ b/azure_arc_k8s_jumpstart/rancher_k3s/vmware/terraform/scripts/az_connect_k3s.sh.tmpl
@@ -32,5 +32,5 @@ sudo chown -R $TF_VAR_admin_user /home/$TF_VAR_admin_user/.azure
 sudo chmod -R 777 /home/$TF_VAR_admin_user/.azure/config
 sudo chmod -R 777 /home/$TF_VAR_admin_user/.azure
 
-sudo az login --service-principal --username $TF_VAR_client_id --password $TF_VAR_client_secret --tenant $TF_VAR_tenant_id
+sudo az login --service-principal --username $TF_VAR_client_id --password=$TF_VAR_client_secret --tenant $TF_VAR_tenant_id
 sudo az connectedk8s connect --name $TF_VAR_arcClusterName --resource-group $TF_VAR_resourceGroup --location $TF_VAR_location --tags 'Project=jumpstart_azure_arc_k8s' --correlation-id "d009f5dd-dba8-4ac7-bac9-b54ef3a6671a"

--- a/azure_arc_k8s_jumpstart/scripts/az_connect_k8s.sh
+++ b/azure_arc_k8s_jumpstart/scripts/az_connect_k8s.sh
@@ -23,7 +23,7 @@ sudo az extension add --name connectedk8s
 sudo az extension add --name k8s-configuration
 
 echo "Log in to Azure using service principal"
-sudo az login --service-principal --username $appId --password $password --tenant $tenantId
+sudo az login --service-principal --username $appId --password=$password --tenant $tenantId
 
 sudo cat <<EOT >> az.sh
 #!/bin/sh

--- a/azure_arc_ml_jumpstart/aks/arm_template/artifacts/AzureMLLogonScript.ps1
+++ b/azure_arc_ml_jumpstart/aks/arm_template/artifacts/AzureMLLogonScript.ps1
@@ -10,7 +10,7 @@ $connectedClusterName = "Arc-AML-AKS"
 Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Login as service principal
-az login --service-principal --username $env:spnClientId --password $env:spnClientSecret --tenant $env:spnTenantId
+az login --service-principal --username $env:spnClientId --password=$Env:spnClientSecret --tenant $env:spnTenantId
 
 # Set default subscription to run commands against
 # "subscriptionId" value comes from clientVM.json ARM template, based on which 

--- a/azure_arc_servers_jumpstart/esu/artifacts/LogonScript.ps1
+++ b/azure_arc_servers_jumpstart/esu/artifacts/LogonScript.ps1
@@ -125,7 +125,7 @@ Start-Transcript -Path $logFilePath -Force -ErrorAction SilentlyContinue
 
     # Required for CLI commands
     Write-Host "Az CLI Login"
-    az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
+    az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
     # Register Azure providers
     Write-Host "Registering Providers"

--- a/azure_arc_servers_jumpstart/local/vagrant/ubuntu/scripts/install_arc_agent.sh
+++ b/azure_arc_servers_jumpstart/local/vagrant/ubuntu/scripts/install_arc_agent.sh
@@ -7,7 +7,7 @@ source /tmp/vars.sh
 
 # Installing Azure CLI
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-az login --service-principal --username $appId --password $password --tenant $tenantId
+az login --service-principal --username $appId --password=$password --tenant $tenantId
 az group create --location $location --name $resourceGroup --subscription $subscriptionId
 
 # Creating cleanup script for 'vagrant destory'

--- a/azure_arc_servers_jumpstart/local/vagrant/windows/scripts/install_arc_agent.ps1
+++ b/azure_arc_servers_jumpstart/local/vagrant/windows/scripts/install_arc_agent.ps1
@@ -2,7 +2,7 @@
 Invoke-Expression "C:\runtime\vars.ps1"
 
 # Creating new Azure Arc resource group
-az login --service-principal --username $env:appId --password $env:password --tenant $env:tenantId
+az login --service-principal --username $env:appId --password=$env:password --tenant $env:tenantId
 az group create --location $env:location --name $env:resourceGroup --subscription $env:subscriptionId 
 
 # Creating cleanup script for 'vagrant destory'

--- a/azure_arc_servers_jumpstart/privatelink/artifacts/installArcAgent.ps1
+++ b/azure_arc_servers_jumpstart/privatelink/artifacts/installArcAgent.ps1
@@ -3,7 +3,7 @@ Start-Transcript -Path C:\Temp\ArcInstallScript.log
 
 # Azure Login 
 
-az login --service-principal -u $Env:appId -p $Env:password --tenant $Env:tenantId
+az login --service-principal -u $Env:appId -p=$Env:password --tenant $Env:tenantId
 az account set -s $Env:SubscriptionId
 
 # Configure hosts file for Private link endpoints resolution

--- a/azure_arc_sqlsrv_jumpstart/aws/winsrv/terraform/scripts/sql.ps1.tmpl
+++ b/azure_arc_sqlsrv_jumpstart/aws/winsrv/terraform/scripts/sql.ps1.tmpl
@@ -72,7 +72,7 @@ Write-Host "I am deploying Azure Log Analytics workspace and installing the MMA 
 $servicePrincipalAppId = "${servicePrincipalAppId}"
 $servicePrincipalTenantId = "${servicePrincipalTenantId}"
 $servicePrincipalSecret = "${servicePrincipalSecret}"
-az login --service-principal --username $servicePrincipalAppId --password $servicePrincipalSecret --tenant $servicePrincipalTenantId
+az login --service-principal --username $servicePrincipalAppId --password=$servicePrincipalSecret --tenant $servicePrincipalTenantId
 
 # Set Log Analytics Workspace Environment Variables
 $resourceGroup = "${resourceGroup}"

--- a/azure_arc_sqlsrv_jumpstart/azure/windows/defender_sql/arm_template/scripts/ArcServersLogonScript.ps1
+++ b/azure_arc_sqlsrv_jumpstart/azure/windows/defender_sql/arm_template/scripts/ArcServersLogonScript.ps1
@@ -35,6 +35,7 @@ $Env:AZURE_CONFIG_DIR = $cliDir.FullName
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
+az config set extension.use_dynamic_install=yes_without_prompt
 az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Register Azure providers

--- a/azure_arc_sqlsrv_jumpstart/azure/windows/defender_sql/arm_template/scripts/ArcServersLogonScript.ps1
+++ b/azure_arc_sqlsrv_jumpstart/azure/windows/defender_sql/arm_template/scripts/ArcServersLogonScript.ps1
@@ -35,7 +35,7 @@ $Env:AZURE_CONFIG_DIR = $cliDir.FullName
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Register Azure providers
 Write-Header "Registering Providers"

--- a/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/scripts/sql.ps1.tmpl
+++ b/azure_arc_sqlsrv_jumpstart/gcp/winsrv/terraform/scripts/sql.ps1.tmpl
@@ -72,7 +72,7 @@ Write-Host "I am deploying Azure Log Analytics workspace and installing the MMA 
 $servicePrincipalAppId = "${servicePrincipalAppId}"
 $servicePrincipalTenantId = "${servicePrincipalTenantId}"
 $servicePrincipalSecret = "${servicePrincipalSecret}"
-az login --service-principal --username $servicePrincipalAppId --password $servicePrincipalSecret --tenant $servicePrincipalTenantId
+az login --service-principal --username $servicePrincipalAppId --password=$servicePrincipalSecret --tenant $servicePrincipalTenantId
 
 # Set Log Analytics Workspace Environment Variables
 $resourceGroup = "${resourceGroup}"

--- a/azure_arc_sqlsrv_jumpstart/vmware/winsrv/terraform/scripts/sql.ps1.tmpl
+++ b/azure_arc_sqlsrv_jumpstart/vmware/winsrv/terraform/scripts/sql.ps1.tmpl
@@ -72,7 +72,7 @@ Write-Host "I am deploying Azure Log Analytics workspace and installing the MMA 
 $servicePrincipalAppId = "${servicePrincipalAppId}"
 $servicePrincipalTenantId = "${servicePrincipalTenantId}"
 $servicePrincipalSecret = "${servicePrincipalSecret}"
-az login --service-principal --username $servicePrincipalAppId --password $servicePrincipalSecret --tenant $servicePrincipalTenantId
+az login --service-principal --username $servicePrincipalAppId --password=$servicePrincipalSecret --tenant $servicePrincipalTenantId
 
 # Set Log Analytics Workspace Environment Variables
 $resourceGroup = "${resourceGroup}"

--- a/azure_arc_vsphere_jumpstart/resource_bridge/powershell/vCenter_onboarding.ps1
+++ b/azure_arc_vsphere_jumpstart/resource_bridge/powershell/vCenter_onboarding.ps1
@@ -214,7 +214,7 @@ try {
 
     log "Logging into azure"
 
-    az login --service-principal -u $spnClientId -p $spnClientSecret --tenant $spnTenantId
+    az login --service-principal -u $spnClientId -p=$spnClientSecret --tenant $spnTenantId
 
     az account set -s $subscriptionId
     if ($LASTEXITCODE) {

--- a/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/LogonScript.ps1
+++ b/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/LogonScript.ps1
@@ -194,7 +194,7 @@ if (-not $($cliDir.Parent.Attributes.HasFlag([System.IO.FileAttributes]::Hidden)
 $Env:AZURE_CONFIG_DIR = $cliDir.FullName
 
 Write-Host "[$(Get-Date -Format t)] INFO: Logging into Az CLI using the service principal and secret provided at deployment" -ForegroundColor DarkGray
-az login --service-principal --username $spnClientID --password $spnClientSecret --tenant $spnTenantId
+az login --service-principal --username $spnClientID --password=$spnClientSecret --tenant $spnTenantId
 az account set --subscription $subscriptionId
 
 # Installing Azure CLI extensions

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -60,7 +60,7 @@ if (-not $($cliDir.Parent.Attributes.HasFlag([System.IO.FileAttributes]::Hidden)
 $Env:AZURE_CONFIG_DIR = $cliDir.FullName
 
 Write-Host "[$(Get-Date -Format t)] INFO: Logging into Az CLI using the service principal and secret provided at deployment" -ForegroundColor Gray
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\AzCLI.log")
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId | Out-File -Append -FilePath ($AgConfig.AgDirectories["AgLogsDir"] + "\AzCLI.log")
 
 # Making extension install dynamic
 if ($AgConfig.AzCLIExtensions.Count -ne 0) {

--- a/azure_jumpstart_ag/artifacts/workflows/pos-app-build-canary.yml
+++ b/azure_jumpstart_ag/artifacts/workflows/pos-app-build-canary.yml
@@ -31,7 +31,7 @@ jobs:
         ACR_NAME: ${{ secrets.ACR_NAME }}
         namespace: "staging"
       run: |
-        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password ${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
+        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password=${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
         LATEST_TAG=$(az acr repository show-tags --name $ACR_NAME --repository $namespace/contoso-supermarket/pos --orderby time_desc --top 1 --output tsv)
         echo $LATEST_TAG
         echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
@@ -42,7 +42,7 @@ jobs:
         ACR_NAME: ${{ secrets.ACR_NAME }}
         namespace: "canary"
       run: |
-        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password ${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
+        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password=${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
         CANARY_LATEST_TAG=$(az acr repository show-tags --name $ACR_NAME --repository $namespace/contoso-supermarket/pos --orderby time_desc --top 1 --output tsv)
         echo $CANARY_LATEST_TAG
         echo "latest_tag=$CANARY_LATEST_TAG" >> $GITHUB_OUTPUT

--- a/azure_jumpstart_ag/artifacts/workflows/pos-app-build-production.yml
+++ b/azure_jumpstart_ag/artifacts/workflows/pos-app-build-production.yml
@@ -31,7 +31,7 @@ jobs:
         ACR_NAME: ${{ secrets.ACR_NAME }}
         namespace: "canary"
       run: |
-        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password ${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
+        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password=${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
         LATEST_TAG=$(az acr repository show-tags --name $ACR_NAME --repository $namespace/contoso-supermarket/pos --orderby time_desc --top 1 --output tsv)
         echo $LATEST_TAG
         echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
@@ -42,7 +42,7 @@ jobs:
         ACR_NAME: ${{ secrets.ACR_NAME }}
         namespace: "production"
       run: |
-        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password ${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
+        az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password=${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
         PROD_LATEST_TAG=$(az acr repository show-tags --name $ACR_NAME --repository $namespace/contoso-supermarket/pos --orderby time_desc --top 1 --output tsv)
         echo $PROD_LATEST_TAG
         echo "latest_tag=$PROD_LATEST_TAG" >> $GITHUB_OUTPUT

--- a/azure_jumpstart_ag/artifacts/workflows/pos-app-build-staging.yml
+++ b/azure_jumpstart_ag/artifacts/workflows/pos-app-build-staging.yml
@@ -38,7 +38,7 @@ jobs:
           ACR_NAME: ${{ secrets.ACR_NAME }}
           namespace: "dev"
         run: |
-          az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password ${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
+          az login --service-principal --username ${{ secrets.SPN_CLIENT_ID }} --password=${{ secrets.SPN_CLIENT_SECRET }} --tenant ${{ secrets.SPN_TENANT_ID }}
           LATEST_TAG=$(az acr repository show-tags --name $ACR_NAME --repository $namespace/contoso-supermarket/pos --orderby time_desc --top 1 --output tsv)
           NEW_VERSION=$(echo $LATEST_TAG | awk -F. '{$NF = $NF + 1;} 1' OFS=.)
           echo $NEW_VERSION

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -124,7 +124,7 @@ if ($Env:flavor -ne "DevOps") {
 
     # Required for CLI commands
     Write-Header "Az CLI Login"
-    az login --service-principal --username $spnClientId --password $spnClientSecret --tenant $spnTenantId
+    az login --service-principal --username $spnClientId --password=$spnClientSecret --tenant $spnTenantId
 
     # Register Azure providers
     Write-Header "Registering Providers"

--- a/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
@@ -32,7 +32,7 @@ Connect-AzAccount -Credential $psCred -TenantId $Env:spnTenantId -ServicePrincip
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Register Azure providers
 Write-Header "Registering Providers"

--- a/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
@@ -192,7 +192,7 @@ foreach ($cluster in $clusters) {
             --auto-upgrade false `
             --scope cluster `
             --release-namespace arc `
-            --version 1.18.0 `
+            --version 1.26.0 `
             --config Microsoft.CustomLocation.ServiceAccount=sa-bootstrapper
 
         Write-Host "`n"

--- a/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
@@ -192,7 +192,7 @@ foreach ($cluster in $clusters) {
             --auto-upgrade false `
             --scope cluster `
             --release-namespace arc `
-            --version 1.26.0 `
+            --version 1.18.0 `
             --config Microsoft.CustomLocation.ServiceAccount=sa-bootstrapper
 
         Write-Host "`n"

--- a/azure_jumpstart_arcbox/artifacts/DataServicesLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DataServicesLogonScript.ps1
@@ -22,7 +22,7 @@ Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 Write-Header "Installing Azure CLI extensions"

--- a/azure_jumpstart_arcbox/artifacts/Deploy-APIM.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Deploy-APIM.ps1
@@ -22,7 +22,7 @@ catch {
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 az config set extension.use_dynamic_install=yes_without_prompt
 
 ################################################

--- a/azure_jumpstart_arcbox/artifacts/DeployAPIM.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DeployAPIM.ps1
@@ -22,7 +22,7 @@ catch {
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
 az config set extension.use_dynamic_install=yes_without_prompt
 
 ################################################

--- a/azure_jumpstart_arcbox/artifacts/DevOpsLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DevOpsLogonScript.ps1
@@ -36,7 +36,7 @@ $Env:capiArcDataClusterName=$Env:capiArcDataClusterName -replace "`n",""
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Downloading CAPI Kubernetes cluster kubeconfig file
 Write-Header "Downloading CAPI K8s Kubeconfig"

--- a/azure_jumpstart_arcbox/artifacts/MonitorWorkbookLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/MonitorWorkbookLogonScript.ps1
@@ -4,7 +4,7 @@ $ArcBoxLogsDir = "$ArcBoxDir\Logs"
 Start-Transcript -Path $ArcBoxLogsDir\MonitorWorkbookLogonScript.log
 
 # Required for CLI commands
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Configure mgmtMonitorWorkbook.json template with subscription ID and resource group values
 Write-Host "Configuring Azure Monitor Workbook ARM template."

--- a/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1
+++ b/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1
@@ -17,7 +17,7 @@ $appClonedRepo = "https://github.com/$Env:githubUser/azure-arc-jumpstart-apps"
 Start-Transcript -Path $Env:ArcBoxLogsDir\K3sGitOps.log
 
 Write-Host "Login to Az CLI using the service principal"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sRBAC.ps1
+++ b/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sRBAC.ps1
@@ -8,7 +8,7 @@ $appClonedRepo = "https://github.com/$Env:githubUser/azure-arc-jumpstart-apps"
 Start-Transcript -Path $Env:ArcBoxLogsDir\K3sRBAC.log
 
 # echo "Login to Az CLI using the service principal"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Making extension install dynamic
 az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_jumpstart_arcbox/artifacts/installCAPI.sh
+++ b/azure_jumpstart_arcbox/artifacts/installCAPI.sh
@@ -51,7 +51,7 @@ sudo -u $adminUsername az extension add --name k8s-configuration
 sudo -u $adminUsername az extension add --name k8s-extension
 
 echo "Log in to Azure"
-sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
+sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password=$SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 subscriptionId=$(sudo -u $adminUsername az account show --query id --output tsv)
 export AZURE_RESOURCE_GROUP=$(sudo -u $adminUsername az resource list --query "[?name=='$stagingStorageAccountName']".[resourceGroup] --resource-type "Microsoft.Storage/storageAccounts" -o tsv)
 az -v

--- a/azure_jumpstart_arcbox/artifacts/installK3s.sh
+++ b/azure_jumpstart_arcbox/artifacts/installK3s.sh
@@ -77,7 +77,7 @@ sudo -u $adminUsername az extension add --name k8s-extension
 
 echo ""
 echo "Log in to Azure"
-sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password $SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
+sudo -u $adminUsername az login --service-principal --username $SPN_CLIENT_ID --password=$SPN_CLIENT_SECRET --tenant $SPN_TENANT_ID
 az -v
 echo ""
 

--- a/azure_jumpstart_hcibox/artifacts/Deploy-ArcResourceBridge.ps1
+++ b/azure_jumpstart_hcibox/artifacts/Deploy-ArcResourceBridge.ps1
@@ -88,7 +88,7 @@ Invoke-Command -VMName $SDNConfig.HostList[0] -Credential $adcred -ScriptBlock {
     $WarningPreference = "SilentlyContinue"
     [System.Environment]::SetEnvironmentVariable('Path', [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\",[System.EnvironmentVariableTarget]::Machine)
     $Env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
-    az login --service-principal --username $using:spnClientID --password $using:spnSecret --tenant $using:spnTenantId
+    az login --service-principal --username $using:spnClientID --password=$using:spnSecret --tenant $using:spnTenantId
     az provider register -n Microsoft.ResourceConnector --wait
     az arcappliance validate hci --config-file $using:csv_path\ResourceBridge\hci-appliance.yaml --only-show-errors
     az arcappliance prepare hci --config-file $using:csv_path\ResourceBridge\hci-appliance.yaml --only-show-errors

--- a/azure_jumpstart_hcibox/artifacts/Deploy-GitOps.ps1
+++ b/azure_jumpstart_hcibox/artifacts/Deploy-GitOps.ps1
@@ -43,7 +43,7 @@ $Env:AZURE_CONFIG_DIR = $cliDir.FullName
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 az config set extension.use_dynamic_install=yes_without_prompt
 
 # Required for azcopy

--- a/azure_jumpstart_hcibox/artifacts/Deploy-SQLMI.ps1
+++ b/azure_jumpstart_hcibox/artifacts/Deploy-SQLMI.ps1
@@ -127,7 +127,7 @@ Invoke-Command -VMName $SDNConfig.HostList[0] -Credential $adcred -ScriptBlock {
     [System.Environment]::SetEnvironmentVariable('Path', $env:Path + ";C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin", [System.EnvironmentVariableTarget]::Machine)
     $Env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
     az config set extension.use_dynamic_install=yes_without_prompt --only-show-errors
-    az login --service-principal --username $using:spnClientID --password $using:spnSecret --tenant $using:spnTenantId
+    az login --service-principal --username $using:spnClientID --password=$using:spnSecret --tenant $using:spnTenantId
     az extension add --name arcdata --system --only-show-errors
     Get-AksHciCredential -name $using:clusterName -Confirm:$false
     Write-Host "Installing the Arc Data extension"

--- a/azure_jumpstart_hcibox/artifacts/HCIBoxLogonScript.ps1
+++ b/azure_jumpstart_hcibox/artifacts/HCIBoxLogonScript.ps1
@@ -41,7 +41,7 @@ New-Item -Path "V:\" -Name "VMs" -ItemType "directory"
 
 # Required for CLI commands
 Write-Header "Az CLI Login"
-az login --service-principal --username $Env:spnClientID --password $Env:spnClientSecret --tenant $Env:spnTenantId
+az login --service-principal --username $Env:spnClientID --password=$Env:spnClientSecret --tenant $Env:spnTenantId
 
 # Register Azure providers
 Write-Header "Registering Providers"

--- a/azure_jumpstart_hcibox/artifacts/Uninstall-ResourceBridge.ps1
+++ b/azure_jumpstart_hcibox/artifacts/Uninstall-ResourceBridge.ps1
@@ -34,7 +34,7 @@ $custom_location_name = "hcibox-rb-cl"
 Invoke-Command -VMName $SDNConfig.HostList[0] -Credential $adcred -ScriptBlock {
     Write-Host "Removing Arc Resource Bridge."
     $WarningPreference = "SilentlyContinue"
-    az login --service-principal --username $using:spnClientID --password $using:spnSecret --tenant $using:spnTenantId
+    az login --service-principal --username $using:spnClientID --password=$using:spnSecret --tenant $using:spnTenantId
 
     az azurestackhci virtualnetwork delete --subscription $using:subId --resource-group $using:rg --name "vlan200" --yes
     az azurestackhci galleryimage delete --subscription $using:subId --resource-group $using:rg --name "ubuntu20"


### PR DESCRIPTION
Modify all "az login" commands' password switch to be:

`az login --service-principal --username $Env:spnClientId --password=$Env:spnClientSecret --tenant $Env:spnTenantId
`

Instead of 

`az login --service-principal --username $Env:spnClientId --password $Env:spnClientSecret --tenant $Env:spnTenantId
`

To avoid command failure in situations where the password starts with a hyphen.