### PR TITLE
Azure Arc-enabled servers - update secure string variable type

### DIFF
--- a/azure_arc_servers_jumpstart/azure/linux/arm_template/azuredeploy.json
+++ b/azure_arc_servers_jumpstart/azure/linux/arm_template/azuredeploy.json
@@ -114,7 +114,7 @@
       }
     },
     "servicePrincipalClientSecret": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Azure service principal password"
       }

--- a/azure_arc_servers_jumpstart/azure/windows/arm_template/azuredeploy.json
+++ b/azure_arc_servers_jumpstart/azure/windows/arm_template/azuredeploy.json
@@ -64,7 +64,7 @@
             }
         },
         "password": {
-            "type": "string",
+            "type": "securestring",
             "metadata": {
                 "description": "Unique SPN password"
             }

--- a/azure_arc_servers_jumpstart/privatelink/azuredeploy.json
+++ b/azure_arc_servers_jumpstart/privatelink/azuredeploy.json
@@ -348,7 +348,7 @@
                             "type": "string"
                         },
                         "sharedKey": {
-                            "type": "string"
+                            "type": "securestring"
                         }
                     },
                     "resources": [

--- a/azure_arc_sqlsrv_jumpstart/azure/windows/archive/vanilla/arm_template/azuredeploy.json
+++ b/azure_arc_sqlsrv_jumpstart/azure/windows/archive/vanilla/arm_template/azuredeploy.json
@@ -44,7 +44,7 @@
             }
         },
         "servicePrincipalSecret": {
-            "type": "string",
+            "type": "securestring",
             "metadata": {
                 "description": "Unique SPN password"
             }


### PR DESCRIPTION
Update the Azure Arc-enabled servers to have the sharedkey param as secure string