### PR TITLE
Arcbox 3.0 task 930 integration tests

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -173,6 +173,7 @@ Invoke-WebRequest ($templateBaseUrl + "artifacts/dsc/common.dsc.yml") -OutFile $
 Invoke-WebRequest ($templateBaseUrl + "artifacts/dsc/virtual_machines_sql.dsc.yml") -OutFile $Env:ArcBoxDscDir\virtual_machines_sql.dsc.yml
 Invoke-WebRequest ($templateBaseUrl + "artifacts/tests/arcbox-bginfo.bgi") -OutFile $Env:ArcBoxTestsDir\arcbox-bginfo.bgi
 Invoke-WebRequest ($templateBaseUrl + "artifacts/tests/common.tests.ps1") -OutFile $Env:ArcBoxTestsDir\common.tests.ps1
+Invoke-WebRequest ($templateBaseUrl + "artifacts/tests/Invoke-Test.ps1") -OutFile $Env:ArcBoxTestsDir\Invoke-Test.ps1
 Invoke-WebRequest ($templateBaseUrl + "artifacts/WinGet.ps1") -OutFile $Env:ArcBoxDir\WinGet.ps1
 Invoke-WebRequest ($templateBaseUrl + "../tests/GHActionDeploy.ps1") -OutFile "$Env:ArcBoxDir\GHActionDeploy.ps1"
 Invoke-WebRequest ($templateBaseUrl + "../tests/OpenSSHDeploy.ps1") -OutFile "$Env:ArcBoxDir\OpenSSHDeploy.ps1"

--- a/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
+++ b/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
@@ -1,5 +1,9 @@
 Start-Transcript -Path C:\ArcBox\logs\Get-PesterResult.log -Force
 
+$Env:ArcBoxDir = "C:\ArcBox"
+$Env:ArcBoxLogsDir = "$Env:ArcBoxDir\Logs"
+$Env:ArcBoxTestsDir = "$Env:ArcBoxDir\Tests"
+
 Write-Output "Get-PesterResult.ps1 started in $(hostname.exe) as user $(whoami.exe) at $(Get-Date)"
 
 $timeout = New-TimeSpan -Minutes 180


### PR DESCRIPTION
This pull request introducing changes that enhance the testing environment and improve the management of environment variables. The key changes involve the addition of a new test script in `Bootstrap.ps1` and the declaration of environment variables in `Send-PesterResult.ps1`.

Key changes include:

* [`azure_jumpstart_arcbox/artifacts/Bootstrap.ps1`](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R176): A new test script `Invoke-Test.ps1` has been added to the list of scripts fetched by `Invoke-WebRequest`. This suggests the introduction of a new test to the suite.

* [`azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1`](diffhunk://#diff-13887494d2524e50972f149ae953f7ed154f61e64afd9cb2f80031c07977f153R3-R6): Several environment variables (`ArcBoxDir`, `ArcBoxLogsDir`, `ArcBoxTestsDir`) have been declared at the start of the script. This change improves the management of these directories throughout the script.