### PR TITLE
Arcbox 3.0 task 930 integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
         ScriptType: FilePath
         azurePowerShellVersion: 'LatestVersion'
         ScriptPath: 'azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Wait-ArcBoxDeployment.ps1'
-        ScriptArguments: -ResourceGroupName $(ResourceGroupName)
+        ScriptArguments: -ResourceGroupName $(ResourceGroupName) -githubAccount $(githubAccount) -githubBranch $(githubBranch)
 
     - task: AzurePowerShell@5
       displayName: 'Download Pester test-results from storage account to pipeline agent'

--- a/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
+++ b/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
@@ -1,8 +1,8 @@
-Start-Transcript -Path C:\ArcBox\logs\Get-PesterResult.log -Force
-
 $Env:ArcBoxDir = "C:\ArcBox"
 $Env:ArcBoxLogsDir = "$Env:ArcBoxDir\Logs"
 $Env:ArcBoxTestsDir = "$Env:ArcBoxDir\Tests"
+
+Start-Transcript -Path "$Env:ArcBoxLogsDir\Get-PesterResult.log" -Force
 
 Write-Output "Get-PesterResult.ps1 started in $(hostname.exe) as user $(whoami.exe) at $(Get-Date)"
 

--- a/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Wait-ArcBoxDeployment.ps1
+++ b/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Wait-ArcBoxDeployment.ps1
@@ -1,12 +1,16 @@
 param(
     [Parameter(Mandatory=$true)]
-    [string]$ResourceGroupName
+    [string]$ResourceGroupName,
+    [Parameter(Mandatory=$true)]
+    [string]$githubAccount,
+    [Parameter(Mandatory=$true)]
+    [string]$githubBranch
 )
 
 Write-Host "Starting VM Run Command to wait for deployment and retrieve Pester test results from ArcBox-Client in resource group $ResourceGroupName"
 
 $Location = (Get-AzVM -ResourceGroupName $ResourceGroupName).Location
-Set-AzVMRunCommand -ResourceGroupName $ResourceGroupName -VMName ArcBox-Client -RunCommandName RetrievePesterResults -Location $Location -SourceScriptUri "https://raw.githubusercontent.com/microsoft/azure_arc/arcbox_3.0/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1" -AsyncExecution
+Set-AzVMRunCommand -ResourceGroupName $ResourceGroupName -VMName ArcBox-Client -RunCommandName RetrievePesterResults -Location $Location -SourceScriptUri "https://raw.githubusercontent.com/$githubAccount/azure_arc/$githubBranch/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1" -AsyncExecution
 
 do {
     $job = Get-AzVMRunCommand -ResourceGroupName $ResourceGroupName -VMName ArcBox-Client -RunCommandName RetrievePesterResults -Expand InstanceView

--- a/azure_jumpstart_arcbox/artifacts/tests/Invoke-Test.ps1
+++ b/azure_jumpstart_arcbox/artifacts/tests/Invoke-Test.ps1
@@ -1,3 +1,6 @@
+$Env:ArcBoxDir = "C:\ArcBox"
+$Env:ArcBoxTestsDir = "$Env:ArcBoxDir\Tests"
+
 Invoke-Pester -Path "$Env:ArcBoxTestsDir\common.tests.ps1" -Output Detailed -PassThru -OutVariable tests_common
 $tests_passed = $tests_common.Passed.Count
 $tests_failed = $tests_common.Failed.Count


### PR DESCRIPTION
This pull request introduces additional parameters in the `azure-pipelines.yml` file and the `Wait-ArcBoxDeployment.ps1` script, modifies the transcript path in the `Send-PesterResult.ps1` script, and sets up environment variables in the `Invoke-Test.ps1` script.

Changes to Azure pipeline and scripts:

* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L113-R113): Modified the `ScriptArguments` in the `stages` section to include `-githubAccount $(githubAccount)` and `-githubBranch $(githubBranch)`. This change allows the pipeline to pass these additional parameters to the scripts.

* [`azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Wait-ArcBoxDeployment.ps1`](diffhunk://#diff-0bb634412115ffc6964fdde024c1bfa9c0482401cb0d14080a602336ef1287a9L3-R13): Added mandatory parameters `githubAccount` and `githubBranch` to the script. These parameters are used in the `Set-AzVMRunCommand` command to specify the source script URI.

Changes to scripts:

* [`azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1`](diffhunk://#diff-13887494d2524e50972f149ae953f7ed154f61e64afd9cb2f80031c07977f153L1-R6): Changed the transcript path from a hardcoded path to a path that uses the environment variable `$Env:ArcBoxLogsDir`. This change makes the script more flexible and less error-prone.

* [`azure_jumpstart_arcbox/artifacts/tests/Invoke-Test.ps1`](diffhunk://#diff-043e2393b931749dfeba1ad738381f22ecc158511f68a5a9d96525127077f0f1R1-R3): Added environment variables `ArcBoxDir` and `ArcBoxTestsDir` at the beginning of the script. These variables are used to specify the path for invoking Pester tests.