### PR TITLE
add missing '$' to aadgroupID parameter

### DIFF
--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Configure-AKSWorkloadCluster.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Configure-AKSWorkloadCluster.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = 'SilentlyContinue'
 
 # Set aadgroupID to the object ID of the Microsoft Entra group that will be granted access to the AKS workload cluster.
-#aadgroupID="xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
+#$aadgroupID="xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
 # Set paths
 $Env:HCIBoxDir = "C:\HCIBox"


### PR DESCRIPTION
THe aadgroupID parameter is missing a $ character which is causing the script to fail when we follow the documentation as is.