### PR TITLE
Initial PR for Agora manufacturing monitoring

### DIFF
--- a/azure_jumpstart_ag/manufacturing/bicep/mgmt/VMInsightsDCR.bicep
+++ b/azure_jumpstart_ag/manufacturing/bicep/mgmt/VMInsightsDCR.bicep
@@ -1,0 +1,56 @@
+@description('This is the name of the AMA-VMI Data Collection Rule(DCR)')
+@metadata({ displayName: 'Name of the Data Collection Rule(DCR)' })
+param DcrName string
+
+@description('Workspace Location.')
+param WorkspaceLocation string
+
+@description('Workspace Resource ID.')
+param WorkspaceResourceId string
+
+resource MSVMI_PerfandDa_Dcr 'Microsoft.Insights/dataCollectionRules@2021-04-01' = {
+  name: 'MSVMI-PerfandDa-${DcrName}'
+  location: WorkspaceLocation
+  properties: {
+    description: 'Data collection rule for VM Insights.'
+    dataSources: {
+      performanceCounters: [
+        {
+          name: 'VMInsightsPerfCounters'
+          streams: ['Microsoft-InsightsMetrics']
+          scheduledTransferPeriod: 'PT1M'
+          samplingFrequencyInSeconds: 60
+          counterSpecifiers: ['\\VmInsights\\DetailedMetrics']
+        }
+      ]
+      extensions: [
+        {
+          streams: ['Microsoft-ServiceMap']
+          extensionName: 'DependencyAgent'
+          extensionSettings: {}
+          name: 'DependencyAgentDataSource'
+        }
+      ]
+    }
+    destinations: {
+      logAnalytics: [
+        {
+          workspaceResourceId: WorkspaceResourceId
+          name: 'VMInsightsPerf-Logs-Dest'
+        }
+      ]
+    }
+    dataFlows: [
+      {
+        streams: ['Microsoft-InsightsMetrics']
+        destinations: ['VMInsightsPerf-Logs-Dest']
+      }
+      {
+        streams: ['Microsoft-ServiceMap']
+        destinations: ['VMInsightsPerf-Logs-Dest']
+      }
+    ]
+  }
+}
+
+output id string = MSVMI_PerfandDa_Dcr.id

--- a/azure_jumpstart_ag/manufacturing/bicep/mgmt/mgmtArtifacts.bicep
+++ b/azure_jumpstart_ag/manufacturing/bicep/mgmt/mgmtArtifacts.bicep
@@ -12,6 +12,9 @@ param resourceTags object = {
 @description('SKU, leave default pergb2018')
 param sku string = 'pergb2018'
 
+@description('Suffix of Data Collection Rule for VM Insights: MSVMI-PerfandDa-"suffix"')
+param VMIDCRName string = 'Agora'
+
 var security = {
   name: 'Security(${workspaceName})'
   galleryName: 'Security'
@@ -47,6 +50,15 @@ module policyDeploymentRGScope './policyAzureArcRGScope.bicep' = {
   name: 'policyDeployment'
   params: {
     azureLocation: location
-    logAnalyticsWorkspaceId: workspace.id
+    VMInsightsDCRId: VMI_DCR_Deployment.outputs.id
+  }
+}
+
+module VMI_DCR_Deployment './VMInsightsDCR.bicep' = {
+  name: 'VMI-DCR-Deployment-${uniqueString(VMIDCRName)}'
+  params: {
+    DcrName: VMIDCRName
+    WorkspaceLocation: location
+    WorkspaceResourceId: workspace.id
   }
 }

--- a/azure_jumpstart_ag/manufacturing/bicep/mgmt/policyAzureArcRGScope.bicep
+++ b/azure_jumpstart_ag/manufacturing/bicep/mgmt/policyAzureArcRGScope.bicep
@@ -7,7 +7,7 @@ param logAnalyticsWorkspaceId string
 var policies = [
   {
     name: '(Ag) Enable Azure Monitor for Hybrid VMs with AMA'
-    definitionId: '/providers/Microsoft.Authorization/policySetDefinitions/59e9c3eb-d8df-473b-8059-23fd38ddd0f0'
+    definitionId: '/providers/Microsoft.Authorization/policySetDefinitions/2b00397d-c309-49c4-aa5a-f0b2c5bc6321'
     roleDefinition:  [
       '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293'
       '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/cd570a14-e51a-42ad-bac8-bafd67325302'

--- a/azure_jumpstart_ag/manufacturing/bicep/mgmt/policyAzureArcRGScope.bicep
+++ b/azure_jumpstart_ag/manufacturing/bicep/mgmt/policyAzureArcRGScope.bicep
@@ -1,8 +1,8 @@
 @description('Location of your Azure resources')
 param azureLocation string
 
-@description('Name of your log analytics workspace')
-param logAnalyticsWorkspaceId string
+@description('Resource ID of Data Collection Rule for VM Insights')
+param VMInsightsDCRId string
 
 var policies = [
   {
@@ -15,8 +15,8 @@ var policies = [
     ]
     scope: resourceGroup().id
     parameters: {
-      logAnalyticsWorkspace: {
-        value: logAnalyticsWorkspaceId
+      dcrResourceId: {
+        value: VMInsightsDCRId
       }
       enableProcessesAndDependencies: {
         value: true


### PR DESCRIPTION
This pull request primarily focuses on improving the Azure PowerShell scripts in `AgLogonScript.ps1` and modifying the Azure Resource Manager Bicep files for better management of Azure resources. The major changes include the consolidation of Azure account connection commands in PowerShell and the introduction of Data Collection Rule (DCR) for VM Insights in the Bicep files.

Azure PowerShell improvements:
* [`azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1`](diffhunk://#diff-d6de137edc1bf7faf44c2484820ccc08202bdd00a18261989c92ffebcf4c3e2cL95-R95): Consolidated `Connect-AzAccount` and `Set-AzContext` commands by including the `-Subscription` parameter in `Connect-AzAccount`. This change was applied in three different sections of the script. [[1]](diffhunk://#diff-d6de137edc1bf7faf44c2484820ccc08202bdd00a18261989c92ffebcf4c3e2cL95-R95) [[2]](diffhunk://#diff-d6de137edc1bf7faf44c2484820ccc08202bdd00a18261989c92ffebcf4c3e2cL764) [[3]](diffhunk://#diff-d6de137edc1bf7faf44c2484820ccc08202bdd00a18261989c92ffebcf4c3e2cL1093-R1091)

Azure Resource Manager Bicep changes:
* [`azure_jumpstart_ag/manufacturing/bicep/mgmt/VMInsightsDCR.bicep`](diffhunk://#diff-ff23634d57ab4ca61cd983c475315985d6ad227118008de1cc74427526c84489R1-R56): Created a new Bicep file to define the Data Collection Rule (DCR) for VM Insights.
* [`azure_jumpstart_ag/manufacturing/bicep/mgmt/mgmtArtifacts.bicep`](diffhunk://#diff-e76a96ee47767477d92e0e5d8dcfb330a803677bd751689cd1ce4c46c8efdb6aR15-R17): Added a new parameter for the DCR name and included a new module for the DCR deployment. Updated the `policyDeploymentRGScope` module to use the DCR ID instead of the Log Analytics Workspace ID. [[1]](diffhunk://#diff-e76a96ee47767477d92e0e5d8dcfb330a803677bd751689cd1ce4c46c8efdb6aR15-R17) [[2]](diffhunk://#diff-e76a96ee47767477d92e0e5d8dcfb330a803677bd751689cd1ce4c46c8efdb6aL50-R62)
* [`azure_jumpstart_ag/manufacturing/bicep/mgmt/policyAzureArcRGScope.bicep`](diffhunk://#diff-62ec3c4cc1e88507ab9d3015cb58a1d60c3309d51a501ad480107a62d7530609L4-R19): Replaced the Log Analytics Workspace ID with the DCR ID for VM Insights in the policy parameters and updated the policy definition ID.