### PR TITLE
Added error-handing to Deploy-Workbook function

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-manufacturing.psd1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-manufacturing.psd1
@@ -75,6 +75,7 @@
     # Chocolatey packages list
     ChocolateyPackagesList  = @(
         'az.powershell',
+        'bicep',
         'kubernetes-cli',
         'vcredist140',
         'microsoft-edge',

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -1835,23 +1835,45 @@ function Deploy-AIO {
 }
 
 function Deploy-Workbook {
+
     $AgMonitoringDir = $AgConfig.AgDirectories["AgMonitoringDir"]
 
     Write-Host "[$(Get-Date -Format t)] INFO: Deploying Azure Workbook 'Azure Arc-enabled resources inventory'."
     Write-Host "`n"
 
+    $workbookTemplateFilePath = "$AgMonitoringDir\arc-inventory-workbook.bicep"
+
     # Read the content of the workbook template-file
-    $content = Get-Content -Path "$AgMonitoringDir\arc-inventory-workbook.bicep" -Raw
+    $content = Get-Content -Path $workbookTemplateFilePath -Raw
 
     # Replace placeholders with actual values
     $updatedContent = $content -replace 'rg-placeholder', $resourceGroup
     $updatedContent = $updatedContent -replace'/subscriptions/00000000-0000-0000-0000-000000000000', "/subscriptions/$($subscriptionId)"
 
     # Write the updated content back to the file
-    Set-Content -Path $filePath -Value $updatedContent
+    Set-Content -Path $workbookTemplateFilePath -Value $updatedContent
 
     # Deploy the workbook
-    az deployment group create --resource-group $Env:resourceGroup --template-file "$AgMonitoringDir\arc-inventory-workbook.bicep"
+    try {
+
+        $TemplateParameterObject = @{
+            location = $Env:azureLocation
+            workbookDisplayName = 'Azure Arc-enabled resources inventory'
+            workbookType = 'workbook'
+            workbookSourceId = 'azure monitor'
+            workbookId = 'c5c6a9e5-74fc-465a-9f11-1dd10aad501b'
+        }
+
+        New-AzResourceGroupDeployment -ResourceGroupName $Env:resourceGroup -TemplateFile $workbookTemplateFilePath  -ErrorAction Stop -TemplateParameterObject $TemplateParameterObject
+
+        Write-Host "[$(Get-Date -Format t)] INFO: Deployment of template-file $workbookTemplateFilePath succeeded."
+
+    } catch {
+
+        Write-Error "[$(Get-Date -Format t)] ERROR: Deployment of template-file $workbookTemplateFilePath failed. Error details: $PSItem.Exception.Message"
+
+    }
+
 
 }
 

--- a/azure_jumpstart_ag/artifacts/monitoring/arc-inventory-workbook.bicep
+++ b/azure_jumpstart_ag/artifacts/monitoring/arc-inventory-workbook.bicep
@@ -10,9 +10,12 @@ param workbookSourceId string = 'azure monitor'
 @description('The unique guid for this workbook instance')
 param workbookId string = 'c5c6a9e5-74fc-465a-9f11-1dd10aad501b'
 
+@description('The location to deploy the workbook to')
+param location string = resourceGroup().location
+
 resource workbookId_resource 'microsoft.insights/workbooks@2022-04-01' = {
   name: workbookId
-  location: resourceGroup().location
+  location: location
   kind: 'shared'
   properties: {
     displayName: workbookDisplayName


### PR DESCRIPTION
This pull request primarily focuses on improving the deployment and configuration of Azure workbooks in the `azure_jumpstart_ag` project. The most significant changes include the addition of the `bicep` package to the Chocolatey packages list, the refactoring of the `Deploy-Workbook` function in the `AgLogonScript.ps1` file to enhance readability and error handling, and the modification of the workbook deployment location in the `arc-inventory-workbook.bicep` file.

Package Update:

* [`azure_jumpstart_ag/artifacts/PowerShell/AgConfig-manufacturing.psd1`](diffhunk://#diff-40ada83e5ec38750dbffb9721759198d3493b7045f2574e26d14f46423ab0914R78): Added `bicep` to the Chocolatey packages list. This package is necessary for the deployment and management of Azure resources.

Function Refactoring:

* [`azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1`](diffhunk://#diff-d6de137edc1bf7faf44c2484820ccc08202bdd00a18261989c92ffebcf4c3e2cR1838-R1876): The `Deploy-Workbook` function was refactored to improve readability and error handling. A variable was introduced to hold the workbook template file path, and the deployment command was wrapped in a `try-catch` block to handle any errors that occur during the deployment.

Workbook Deployment:

* [`azure_jumpstart_ag/artifacts/monitoring/arc-inventory-workbook.bicep`](diffhunk://#diff-ac5983bcea8a6223250f0090750623a1dce4cf126c71caf04e0c984e2de12fb9R13-R18): The workbook deployment location was changed from `resourceGroup().location` to a new parameter `location`. This allows for more flexibility in specifying the deployment location.