### PR TITLE
HCIBox - Add parameter to enable automatic upgrade of cluster

### DIFF
--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
@@ -16,8 +16,8 @@ param (
     [string]$deployResourceBridge,
     [string]$natDNS,
     [string]$rdpPort,
-    [bool]$autoDeployClusterResource,
-    [bool]$autoUpgradeClusterResource
+    [string]$autoDeployClusterResource,
+    [string]$autoUpgradeClusterResource
 )
 
 [System.Environment]::SetEnvironmentVariable('adminUsername', $adminUsername,[System.EnvironmentVariableTarget]::Machine)

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
@@ -16,7 +16,8 @@ param (
     [string]$deployResourceBridge,
     [string]$natDNS,
     [string]$rdpPort,
-    [bool]$autoDeployClusterResource
+    [bool]$autoDeployClusterResource,
+    [bool]$autoUpgradeClusterResource
 )
 
 [System.Environment]::SetEnvironmentVariable('adminUsername', $adminUsername,[System.EnvironmentVariableTarget]::Machine)
@@ -36,6 +37,7 @@ param (
 [System.Environment]::SetEnvironmentVariable('deployAKSHCI', $deployAKSHCI,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('deployResourceBridge', $deployResourceBridge,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('autoDeployClusterResource', $autoDeployClusterResource,[System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable('autoUpgradeClusterResource', $autoUpgradeClusterResource,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('registerCluster', $registerCluster,[System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('natDNS', $natDNS,[System.EnvironmentVariableTarget]::Machine)
 

--- a/azure_jumpstart_hcibox/bicep/host/host.bicep
+++ b/azure_jumpstart_hcibox/bicep/host/host.bicep
@@ -66,6 +66,9 @@ param rdpPort string = '3389'
 @description('Choice to enable automatic deployment of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Default is false.')
 param autoDeployClusterResource bool = false
 
+@description('Choice to enable automatic upgrade of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Only applicable when autoDeployClusterResource is true. Default is false.')
+param autoUpgradeClusterResource bool = false
+
 var encodedPassword = base64(windowsAdminPassword)
 var bastionName = 'HCIBox-Bastion'
 var publicIpAddressName = deployBastion == false ? '${vmName}-PIP' : '${bastionName}-PIP'
@@ -254,8 +257,7 @@ resource vmBootstrap 'Microsoft.Compute/virtualMachines/extensions@2022-03-01' =
       fileUris: [
         uri(templateBaseUrl, 'artifacts/PowerShell/Bootstrap.ps1')
       ]
-param autoDeployClusterResource
-      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername ${windowsAdminUsername} -adminPassword ${encodedPassword} -spnClientId ${spnClientId} -spnClientSecret ${spnClientSecret} -spnTenantId ${spnTenantId} -subscriptionId ${subscription().subscriptionId} -spnProviderId ${spnProviderId} -resourceGroup ${resourceGroup().name} -azureLocation ${location} -stagingStorageAccountName ${stagingStorageAccountName} -workspaceName ${workspaceName} -templateBaseUrl ${templateBaseUrl} -registerCluster ${registerCluster} -deployAKSHCI ${deployAKSHCI} -deployResourceBridge ${deployResourceBridge} -natDNS ${natDNS} -rdpPort ${rdpPort} -autoDeployClusterResource ${autoDeployClusterResource}'
+      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername ${windowsAdminUsername} -adminPassword ${encodedPassword} -spnClientId ${spnClientId} -spnClientSecret ${spnClientSecret} -spnTenantId ${spnTenantId} -subscriptionId ${subscription().subscriptionId} -spnProviderId ${spnProviderId} -resourceGroup ${resourceGroup().name} -azureLocation ${location} -stagingStorageAccountName ${stagingStorageAccountName} -workspaceName ${workspaceName} -templateBaseUrl ${templateBaseUrl} -registerCluster ${registerCluster} -deployAKSHCI ${deployAKSHCI} -deployResourceBridge ${deployResourceBridge} -natDNS ${natDNS} -rdpPort ${rdpPort} -autoDeployClusterResource ${autoDeployClusterResource} -autoUpgradeClusterResource ${autoUpgradeClusterResource}'
     }
   }
 }

--- a/azure_jumpstart_hcibox/bicep/main.azd.parameters.json
+++ b/azure_jumpstart_hcibox/bicep/main.azd.parameters.json
@@ -31,6 +31,9 @@
         },
         "autoDeployClusterResource": {
             "value": "${JS_AUTO_DEPLOY_CLUSTER_RESOURCE}"
+        },
+        "autoUpdateClusterResource": {
+            "value": "${JS_AUTO_UPDATE_CLUSTER_RESOURCE}"
         }
     }
 }

--- a/azure_jumpstart_hcibox/bicep/main.bicep
+++ b/azure_jumpstart_hcibox/bicep/main.bicep
@@ -44,6 +44,9 @@ param rdpPort string = '3389'
 @description('Choice to enable automatic deployment of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Default is false.')
 param autoDeployClusterResource bool = false
 
+@description('Choice to enable automatic upgrade of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Only applicable when autoDeployClusterResource is true. Default is false.')
+param autoUpgradeClusterResource bool = false
+
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_hcibox/'
 
 module mgmtArtifactsAndPolicyDeployment 'mgmt/mgmtArtifacts.bicep' = {
@@ -87,5 +90,6 @@ module hostDeployment 'host/host.bicep' = {
     location: location
     rdpPort: rdpPort
     autoDeployClusterResource: autoDeployClusterResource
+    autoUpgradeClusterResource: autoUpgradeClusterResource
   }
 }

--- a/azure_jumpstart_hcibox/bicep/main.parameters.json
+++ b/azure_jumpstart_hcibox/bicep/main.parameters.json
@@ -28,6 +28,9 @@
         },
         "autoDeployClusterResource": {
             "value": false
+        },
+        "autoUpdateClusterResource": {
+            "value": false
         }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `azure_jumpstart_hcibox` project to enhance the automation and deployment of the Azure Stack HCI cluster. 

New Parameters:

* [`azure_jumpstart_hcibox/bicep/host/host.bicep`](diffhunk://#diff-88413a633c596449c8ebcf0ed64bc7321f5e6ee2fc8f94a0cee2bb04a64c0dafR66-R71): Added `autoUpgradeClusterResource` parameter to enable automatic upgrade of the Azure Stack HCI cluster resource after the cluster deployment is complete.
