### PR TITLE
HCIBox bugfix - autoUpdateClusterResource -> autoUpgradeClusterResource

### DIFF
--- a/azure_jumpstart_hcibox/bicep/main.azd.bicep
+++ b/azure_jumpstart_hcibox/bicep/main.azd.bicep
@@ -50,6 +50,9 @@ param rdpPort string = '3389'
 @description('Choice to enable automatic deployment of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Default is false.')
 param autoDeployClusterResource bool = false
 
+@description('Choice to enable automatic upgrade of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Only applicable when autoDeployClusterResource is true. Default is false.')
+param autoUpgradeClusterResource bool = false
+
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_hcibox/'
 
 targetScope = 'subscription'
@@ -104,6 +107,7 @@ module hostDeployment 'host/host.bicep' = {
     location: location
     rdpPort: rdpPort
     autoDeployClusterResource: autoDeployClusterResource
+    autoUpgradeClusterResource: autoUpgradeClusterResource
   }
 }
 

--- a/azure_jumpstart_hcibox/bicep/main.azd.parameters.json
+++ b/azure_jumpstart_hcibox/bicep/main.azd.parameters.json
@@ -32,8 +32,8 @@
         "autoDeployClusterResource": {
             "value": "${JS_AUTO_DEPLOY_CLUSTER_RESOURCE}"
         },
-        "autoUpdateClusterResource": {
-            "value": "${JS_AUTO_UPDATE_CLUSTER_RESOURCE}"
+        "autoUpgradeClusterResource": {
+            "value": "${JS_AUTO_UPGRADE_CLUSTER_RESOURCE}"
         }
     }
 }

--- a/azure_jumpstart_hcibox/bicep/main.parameters.json
+++ b/azure_jumpstart_hcibox/bicep/main.parameters.json
@@ -29,7 +29,7 @@
         "autoDeployClusterResource": {
             "value": false
         },
-        "autoUpdateClusterResource": {
+        "autoUpgradeClusterResource": {
             "value": false
         }
     }


### PR DESCRIPTION
This pull request primarily involves changes to the Azure deployment configuration files in the `azure_jumpstart_hcibox/bicep` directory. The main changes include the addition of a new parameter `autoUpgradeClusterResource` which was missing for azd and replacing the existing `autoUpdateClusterResource` with `autoUpgradeClusterResource` to resolve #2498  

Here are the key changes:

Addition of new parameter to azd-deployment:

* [`azure_jumpstart_hcibox/bicep/main.azd.bicep`](diffhunk://#diff-c298dfb8a2ff3e9121e728f5dcde55ae8c697714d006c852d9e43ac6e091b82aR53-R55): A new parameter `autoUpgradeClusterResource` was added with a description. This parameter determines whether to enable automatic upgrade of Azure Arc enabled HCI cluster resource after the client VM deployment is complete.

Parameter usage:

* [`azure_jumpstart_hcibox/bicep/main.azd.bicep`](diffhunk://#diff-c298dfb8a2ff3e9121e728f5dcde55ae8c697714d006c852d9e43ac6e091b82aR110): The newly added parameter `autoUpgradeClusterResource` is used in the `hostDeployment` module.

Parameter renaming:

* [`azure_jumpstart_hcibox/bicep/main.azd.parameters.json`](diffhunk://#diff-7a2997fb95044f67a802d2657db5d32a672d8415bf5d0bf4fc0fb581ece122a3L35-R36): The `autoUpdateClusterResource` parameter was replaced with `autoUpgradeClusterResource`.
* [`azure_jumpstart_hcibox/bicep/main.parameters.json`](diffhunk://#diff-9e8b44c8c6e660231eeb26d110ed0d8f1a5248a3ee0401c49b2e267066203dc6L32-R32): The `autoUpdateClusterResource` parameter was replaced with `autoUpgradeClusterResource`.