### PR TITLE
Adding LogSize for AKS-EE deployments - Fix #2515

### DIFF
--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/L1Files/ScalableCluster.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/L1Files/ScalableCluster.json
@@ -40,6 +40,7 @@
         "CpuCount": 4,
         "MemoryInMB": 4096,
         "DataSizeInGB": 20,
+        "LogSizeInGB": 5,
         "Ip4Address": "Ip4Address-null",
         "TimeoutSeconds": 300,
         "TpmPassthrough": false

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/L1Files/ScalableClusterAdd-k3s.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/L1Files/ScalableClusterAdd-k3s.json
@@ -31,6 +31,7 @@
         "CpuCount": 4,
         "MemoryInMB": 4096,
         "DataSizeInGB": 20,
+        "LogSizeInGB": 5,
         "Ip4Address": "Ip4Address-null",
         "TimeoutSeconds": 300,
         "TpmPassthrough": false

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/L1Files/ScalableClusterAdd-k8s.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/L1Files/ScalableClusterAdd-k8s.json
@@ -32,6 +32,7 @@
         "CpuCount": 4,
         "MemoryInMB": 4096,
         "DataSizeInGB": 20,
+        "LogSizeInGB": 5,
         "Ip4Address": "Ip4Address-null",
         "TimeoutSeconds": 300,
         "TpmPassthrough": false

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/L1Files/ScalableCluster.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/L1Files/ScalableCluster.json
@@ -40,6 +40,7 @@
         "CpuCount": 4,
         "MemoryInMB": 4096,
         "DataSizeInGB": 20,
+        "LogSizeInGB": 5,
         "Ip4Address": "Ip4Address-null",
         "TimeoutSeconds": 300,
         "TpmPassthrough": false

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/L1Files/ScalableClusterAdd-k3s.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/L1Files/ScalableClusterAdd-k3s.json
@@ -31,6 +31,7 @@
         "CpuCount": 4,
         "MemoryInMB": 4096,
         "DataSizeInGB": 20,
+        "LogSizeInGB": 5,
         "Ip4Address": "Ip4Address-null",
         "TimeoutSeconds": 300,
         "TpmPassthrough": false

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/L1Files/ScalableClusterAdd-k8s.json
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/L1Files/ScalableClusterAdd-k8s.json
@@ -32,6 +32,7 @@
         "CpuCount": 4,
         "MemoryInMB": 4096,
         "DataSizeInGB": 20,
+        "LogSizeInGB": 5,
         "Ip4Address": "Ip4Address-null",
         "TimeoutSeconds": 300,
         "TpmPassthrough": false

--- a/azure_jumpstart_ag/retail/artifacts/L1Files/ScalableCluster.json
+++ b/azure_jumpstart_ag/retail/artifacts/L1Files/ScalableCluster.json
@@ -40,6 +40,7 @@
         "CpuCount": 4,
         "MemoryInMB": 24576,
         "DataSizeInGB": 80,
+        "LogSizeInGB": 5,
         "Ip4Address": "Ip4Address-null",
         "TimeoutSeconds": 600,
         "TpmPassthrough": false


### PR DESCRIPTION
A lot of the AKS-EE deployments with multiple pods (like AIO) will fail to schedule pods because of a lack of space in the /var/log (previously limited to 1GB == ~20 pods) folder inside the node. Using ~5GB will let AKS-EE deployments schedule up to +100 pods

Fixes and closes #2515 