### PR TITLE
Replaced Mexico City with Monterrey and country code

### DIFF
--- a/azure_jumpstart_ag/artifacts/data_emulator/data-emulator.py
+++ b/azure_jumpstart_ag/artifacts/data_emulator/data-emulator.py
@@ -29,8 +29,8 @@ production_last_generated = datetime.now()
 
 # Define common schema templates to generate telemetry data
 plant_details = [ 
-    { "plant_id": "PT-01", "location": "Detroit, MI" },
-    { "plant_id": "PT-02", "location": "Mexico City, MX" },
+    { "plant_id": "PT-01", "location": "Detroit, US" },
+    { "plant_id": "PT-02", "location": "Monterrey, MX" },
     { "plant_id": "PT-03", "location": "Shanghai, CN" },
     { "plant_id": "PT-04", "location": "Hamburg, DE" }
 ]


### PR DESCRIPTION
Replaced Mexico City with Monterrey and using country codes for plant geo location