### PR TITLE
Added logic for azd pre-provisioning script to terminate when Microsoft.AzureStackHCI provider id is not retrieved

### DIFF
--- a/azure_jumpstart_hcibox/scripts/preprovision.ps1
+++ b/azure_jumpstart_hcibox/scripts/preprovision.ps1
@@ -166,8 +166,12 @@ azd env set JS_RDP_PORT $JS_RDP_PORT
 # Attempt to retrieve provider id for Microsoft.AzureStackHCI
 Write-Host "Attempting to retrieve Microsoft.AzureStackHCI provider id..."
 $spnProviderId=$(az ad sp list --display-name "Microsoft.AzureStackHCI" --output json) | ConvertFrom-Json
-if ($null -ne $spnProviderId.id) {
-    azd env set SPN_PROVIDER_ID -- $($spnProviderId.id)
+ else {
+    Write-Warning "Microsoft.AzureStackHCI provider id not found, aborting..."
+    
+    Write-Host 'Consider the following options: 1) Request access from a tenant administrator to get read-permissions to service principals.
+    2) Ask a tenant administrator to run the command $(az ad sp list --display-name "Microsoft.AzureStackHCI" --output json) | ConvertFrom-Json and send you the ID from the output. You can then manually add that value to the AZD .env file: SPN_PROVIDER_ID="xxx" or use the Bicep-based deployment specifying spnProviderId="xxx" in the deployment parameter-file.' -ForegroundColor Yellow
+    throw "Microsoft.AzureStackHCI provider id not found"
 }
 
 ########################################################################


### PR DESCRIPTION
This pull request includes a change to the `preprovision.ps1` script in the `azure_jumpstart_hcibox/scripts` directory. The change modifies the script's behavior when the Microsoft.AzureStackHCI provider id is not found. Instead of setting the `SPN_PROVIDER_ID` environment variable, it now issues a warning, provides options for resolution, and aborts the script execution.

* [`azure_jumpstart_hcibox/scripts/preprovision.ps1`](diffhunk://#diff-20e0e2f79cba3a9a67f24a8bd35c422402e2c598b1b7e7d1abae80b7fccb3d19L169-R174): Modified the script to issue a warning and provide resolution options when the Microsoft.AzureStackHCI provider id is not found, instead of setting the `SPN_PROVIDER_ID` environment variable. The script will now also abort execution in this scenario.Throw error if Microsoft.AzureStackHCI provider id is not retrieved.

Fixes #2541 