### PR TITLE
Bugfix - issue 2546

### DIFF
--- a/azure_jumpstart_hcibox/scripts/preprovision.ps1
+++ b/azure_jumpstart_hcibox/scripts/preprovision.ps1
@@ -166,6 +166,8 @@ azd env set JS_RDP_PORT $JS_RDP_PORT
 # Attempt to retrieve provider id for Microsoft.AzureStackHCI
 Write-Host "Attempting to retrieve Microsoft.AzureStackHCI provider id..."
 $spnProviderId=$(az ad sp list --display-name "Microsoft.AzureStackHCI" --output json) | ConvertFrom-Json
+ if ($null -ne $spnProviderId.id) {
+    azd env set SPN_PROVIDER_ID -- $($spnProviderId.id)
  else {
     Write-Warning "Microsoft.AzureStackHCI provider id not found, aborting..."
     


### PR DESCRIPTION
This pull request includes a change to the `preprovision.ps1` script in the `azure_jumpstart_hcibox/scripts` directory. The change involves setting the `SPN_PROVIDER_ID` environment variable if the `Microsoft.AzureStackHCI` provider id is found. 

* [`azure_jumpstart_hcibox/scripts/preprovision.ps1`](diffhunk://#diff-20e0e2f79cba3a9a67f24a8bd35c422402e2c598b1b7e7d1abae80b7fccb3d19R169-R170): Added a conditional statement to check if `spnProviderId.id` is not null. If it's not null, it sets the `SPN_PROVIDER_ID` environment variable using the `azd env set` command.

Fixes #2546 