### PR TITLE
Removed SAS token for VHD downloads

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -13,8 +13,7 @@ $azureLocation = $env:azureLocation
 $resourceGroup = $env:resourceGroup
 
 # Moved VHD storage account details here to keep only in place to prevent duplicates.
-$vhdSourceFolder = "https://jsvhds.blob.core.windows.net/arcbox"
-$sas = "*?si=ArcBox-RL&spr=https&sv=2022-11-02&sr=c&sig=vg8VRjM00Ya%2FGa5izAq3b0axMpR4ylsLsQ8ap3BhrnA%3D"
+$vhdSourceFolder = "https://jsvhds.blob.core.windows.net/arcbox/*"
 
 # Archive existing log file and create new one
 $logFilePath = "$Env:ArcBoxLogsDir\ArcServersLogonScript.log"
@@ -184,7 +183,7 @@ if ($Env:flavor -ne "DevOps") {
         $Env:AZCOPY_BUFFER_GB = 4
         # Other ArcBox flavors does not have an azcopy network throughput capping
         Write-Output "Downloading nested VMs VHDX file for SQL. This can take some time, hold tight..."
-        azcopy cp $vhdSourceFolder/$sas --include-pattern "${SQLvmName}.vhdx" $Env:ArcBoxVMDir --check-length=false --cap-mbps 1200 --log-level=ERROR
+        azcopy cp $vhdSourceFolder --include-pattern "${SQLvmName}.vhdx" $Env:ArcBoxVMDir --check-length=false --cap-mbps 1200 --log-level=ERROR
     }
 
     # Create the nested VMs if not already created
@@ -337,12 +336,12 @@ if ($Env:flavor -ne "DevOps") {
             if ($Env:flavor -eq "Full") {
                 # The "Full" ArcBox flavor has an azcopy network throughput capping
                 Write-Output "Downloading nested VMs VHDX files. This can take some time, hold tight..."
-                azcopy cp $vhdSourceFolder/$sas $Env:ArcBoxVMDir --include-pattern "${Win2k19vmName}.vhdx;${Win2k22vmName}.vhdx;${Ubuntu01vmName}.vhdx;${Ubuntu02vmName}.vhdx;" --recursive=true --check-length=false --cap-mbps 1200 --log-level=ERROR
+                azcopy cp $vhdSourceFolder $Env:ArcBoxVMDir --include-pattern "${Win2k19vmName}.vhdx;${Win2k22vmName}.vhdx;${Ubuntu01vmName}.vhdx;${Ubuntu02vmName}.vhdx;" --recursive=true --check-length=false --cap-mbps 1200 --log-level=ERROR
             }
             else {
                 # Other ArcBox flavors does not have an azcopy network throughput capping
                 Write-Output "Downloading nested VMs VHDX files. This can take some time, hold tight..."
-                azcopy cp $vhdSourceFolder/$sas $Env:ArcBoxVMDir --include-pattern "${Win2k19vmName}.vhdx;${Win2k22vmName}.vhdx;${Ubuntu01vmName}.vhdx;${Ubuntu02vmName}.vhdx;" --recursive=true --check-length=false --log-level=ERROR
+                azcopy cp $vhdSourceFolder $Env:ArcBoxVMDir --include-pattern "${Win2k19vmName}.vhdx;${Win2k22vmName}.vhdx;${Ubuntu01vmName}.vhdx;${Ubuntu02vmName}.vhdx;" --recursive=true --check-length=false --log-level=ERROR
             }
         }
 


### PR DESCRIPTION
This pull request primarily focuses on changes made to the `azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1` file. The changes is aimed at simplifying the way Azure's `azcopy` command is used to copy VHD files from a source folder. The changes remove the use of a Shared Access Signature (SAS) token and modify the `$vhdSourceFolder` variable to directly include the path to the VHD files.

Here are the key changes:

* [`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bL16-R16): The `$vhdSourceFolder` variable was modified to directly include the path to the VHD files, removing the need for the `$sas` variable. This change simplifies the URL used in the `azcopy` command.

* [`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bL187-R186): The `azcopy` command was updated to remove the `$sas` variable from the source URL. This change was made in the conditional block for the "DevOps" flavor.

* [`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bL340-R344): Similar to the previous change, the `azcopy` command was updated to remove the `$sas` variable from the source URL. This change was made in the conditional block for the "Full" flavor and other flavors.

Resolves #2551