### PR TITLE
Updated storage account for VHD files for arcbox_3.0

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -13,7 +13,7 @@ $azureLocation = $env:azureLocation
 $resourceGroup = $env:resourceGroup
 
 # Moved VHD storage account details here to keep only in place to prevent duplicates.
-$vhdSourceFolder = "https://jsvhds.blob.core.windows.net/arcbox/*"
+$vhdSourceFolder = "https://jumpstartprodsg.blob.core.windows.net/arcbox/*"
 
 # Archive existing log file and create new one
 $logFilePath = "$Env:ArcBoxLogsDir\ArcServersLogonScript.log"


### PR DESCRIPTION
This pull request includes a minor change to the `ArcServersLogonScript.ps1` file in the `azure_jumpstart_arcbox/artifacts` directory. The change updates the URL for the `vhdSourceFolder` variable, which is used to specify the source folder for the Virtual Hard Disk (VHD) storage account. This update ensures that the script points to the correct location for the VHD storage account.