### PR TITLE
Update vmSize for clientVm to use v5

### DIFF
--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -172,7 +172,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2022-03-01' = {
   }
   properties: {
     hardwareProfile: {
-      vmSize: flavor == 'DevOps' ? 'Standard_B4ms' : flavor == 'DataOps' ? 'Standard_D8s_v4' : 'Standard_D16s_v4'
+      vmSize: flavor == 'DevOps' ? 'Standard_B4ms' : flavor == 'DataOps' ? 'Standard_D8s_v5' : 'Standard_D16s_v5'
     }
     storageProfile: {
       osDisk: {


### PR DESCRIPTION
This pull request includes a change to the `clientVm.bicep` file in the `azure_jumpstart_arcbox/bicep/clientVm` directory. The change modifies the `vmSize` property in the `hardwareProfile` of the `Microsoft.Compute/virtualMachines@2022-03-01` resource. The `vmSize` for the 'DataOps' flavor has been updated from 'Standard_D8s_v4' to 'Standard_D8s_v5', and for the default case it has been updated from 'Standard_D16s_v4' to 'Standard_D16s_v5'.