### PR TITLE
Added Azure Update Manager to ArcBox

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -353,7 +353,6 @@ if ($flavor -eq "ITPro") {
     # Creating scheduled task for ArcServersLogonScript.ps1
     $Action = New-ScheduledTaskAction -Execute $ScheduledTaskExecutable -Argument $Env:ArcBoxDir\ArcServersLogonScript.ps1
     Register-ScheduledTask -TaskName "ArcServersLogonScript" -User $adminUsername -Action $Action -RunLevel "Highest" -Force
-    Restart-Computer -Force
 }
 
 if ($flavor -eq "DevOps") {
@@ -364,7 +363,6 @@ if ($flavor -eq "DevOps") {
     # Creating scheduled task for DevOpsLogonScript.ps1
     $Action = New-ScheduledTaskAction -Execute $ScheduledTaskExecutable -Argument $Env:ArcBoxDir\DevOpsLogonScript.ps1
     Register-ScheduledTask -TaskName "DevOpsLogonScript" -User $adminUsername -Action $Action -RunLevel "Highest" -Force
-    Restart-Computer -Force
 }
 
 if ($flavor -eq "DataOps") {

--- a/azure_jumpstart_arcbox/bicep/main.bicep
+++ b/azure_jumpstart_arcbox/bicep/main.bicep
@@ -69,7 +69,7 @@ param resourceTags object = {
 }
 
 @maxLength(7)
-@description('The naming prefix for the nested virtual machines. The maximum length for the naming prefix is 7 characters,example: `ArcBox-Win2k19`')
+@description('The naming prefix for the nested virtual machines and all Azure resources deployed. The maximum length for the naming prefix is 7 characters,example: `ArcBox-Win2k19`')
 param namingPrefix string = 'ArcBox'
 
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_arcbox/'

--- a/azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep
+++ b/azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep
@@ -12,6 +12,9 @@ param resourceTags object = {
   Solution: 'jumpstart_arcbox'
 }
 
+param azureUpdateManagerArcPolicyId string = '/providers/Microsoft.Authorization/policyDefinitions/bfea026e-043f-4ff4-9d1b-bf301ca7ff46'
+param azureUpdateManagerAzurePolicyId string = '/providers/Microsoft.Authorization/policyDefinitions/59efceea-0c96-497e-a4a1-4eb2290dac15'
+
 param tagsRoleDefinitionId string = '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c'
 
 var policies = [
@@ -124,3 +127,79 @@ resource policy_tagging_resources 'Microsoft.Authorization/roleAssignments@2020-
     principalType: 'ServicePrincipal'
   }
 }]
+
+resource updateManagerArcPolicyLinux 'Microsoft.Authorization/policyAssignments@2024-04-01' = {
+  name: '(ArcBox) Enable Azure Update Manager for Arc-enabled Linux machines'
+  location: azureLocation
+  scope: resourceGroup()
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    displayName: '(ArcBox) Enable Azure Update Manager for Arc-enabled Linux machines'
+    description: 'Enable Azure Update Manager for Arc-enabled machines'
+    policyDefinitionId: azureUpdateManagerArcPolicyId
+    parameters: {
+      osType: {
+        value: 'Linux'
+      }
+    }
+  }
+}
+
+resource updateManagerArcPolicyWindows 'Microsoft.Authorization/policyAssignments@2024-04-01' = {
+  name: '(ArcBox) Enable Azure Update Manager for Arc-enabled Windows machines'
+  location: azureLocation
+  scope: resourceGroup()
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    displayName: '(ArcBox) Enable Azure Update Manager for Arc-enabled Windows machines'
+    description: 'Enable Azure Update Manager for Arc-enabled machines'
+    policyDefinitionId: azureUpdateManagerArcPolicyId
+    parameters: {
+      osType: {
+        value: 'Windows'
+      }
+    }
+  }
+}
+
+resource updateManagerAzurePolicyWindows  'Microsoft.Authorization/policyAssignments@2024-04-01' = {
+  name: '(ArcBox) Enable Azure Update Manager for Azure Windows machines'
+  location: azureLocation
+  scope: resourceGroup()
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    displayName: '(ArcBox) Enable Azure Update Manager for Azure Windows machines'
+    description: 'Enable Azure Update Manager for Azure machines'
+    policyDefinitionId: azureUpdateManagerAzurePolicyId
+    parameters: {
+      osType: {
+        value: 'Windows'
+      }
+    }
+  }
+}
+
+resource updateManagerAzurePolicyLinux  'Microsoft.Authorization/policyAssignments@2024-04-01' = {
+  name: '(ArcBox) Enable Azure Update Manager for Azure Linux machines'
+  location: azureLocation
+  scope: resourceGroup()
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties:{
+    displayName: '(ArcBox) Enable Azure Update Manager for Azure Linux machines'
+    description: 'Enable Azure Update Manager for Azure machines'
+    policyDefinitionId: azureUpdateManagerAzurePolicyId
+    parameters: {
+      osType: {
+        value: 'Linux'
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request includes several changes to the `azure_jumpstart_arcbox` project, primarily focusing on enhancing the update management capabilities and refining the deployment scripts. The most important changes include updating the PowerShell scripts to trigger update assessments, modifying the Bicep templates to include new policy parameters, and removing unnecessary computer restarts from scheduled tasks.

### PowerShell Script Enhancements:
* Updated `ArcServersLogonScript.ps1` to trigger update assessments for Arc-enabled servers and use `$using` scope for variables in parallel execution. (`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`) [[1]](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bL451-R457) [[2]](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bR473-R476) [[3]](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bR497-R500)

### Bicep Template Modifications:
* Added new parameters for Azure Update Manager policies in `policyAzureArc.bicep`. (`azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep`)
* Included resources for enabling Azure Update Manager policies for both Linux and Windows machines in `policyAzureArc.bicep`. (`azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep`)

### Deployment Script Refinements:
* Removed the `Restart-Computer -Force` command from the scheduled task creation blocks in `Bootstrap.ps1` for both ITPro and DevOps flavors. (`azure_jumpstart_arcbox/artifacts/Bootstrap.ps1`) [[1]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707L356) [[2]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707L367)

### Documentation Update:
* Updated the description for the `namingPrefix` parameter to clarify its use for all Azure resources deployed. (`azure_jumpstart_arcbox/bicep/main.bicep`)