### PR TITLE
Desktop shortcut for Logs-folder

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -49,6 +49,14 @@ $Shortcut.TargetPath = $WinTerminalPath
 $shortcut.WindowStyle = 3
 $shortcut.Save()
 
+# Create desktop shortcut for Logs-folder
+$WshShell = New-Object -comObject WScript.Shell
+$LogsPath = "C:\ArcBox\Logs"
+$Shortcut = $WshShell.CreateShortcut("$Env:USERPROFILE\Desktop\Logs.lnk")
+$Shortcut.TargetPath = $LogsPath
+$shortcut.WindowStyle = 3
+$shortcut.Save()
+
 # Configure Windows Terminal as the default terminal application
 $registryPath = "HKCU:\Console\%%Startup"
 


### PR DESCRIPTION
This pull request includes a modification to the `azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1` file to create a desktop shortcut for the Logs folder.

Desktop shortcut creation:

* [`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bR52-R59): Added code to create a desktop shortcut for the `C:\ArcBox\Logs` folder.