### PR TITLE
ArcBox 3.0 - Adding a new parameter for the GitHub branch and improving the configuration logic

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -25,6 +25,7 @@ param (
     [string]$k3sArcClusterName,
     [string]$aksArcClusterName,
     [string]$aksdrArcClusterName,
+    [string]$githubBranch,
     [string]$githubUser,
     [string]$templateBaseUrl,
     [string]$flavor,
@@ -57,6 +58,7 @@ param (
 [System.Environment]::SetEnvironmentVariable('workspaceName', $workspaceName, [System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('k3sArcDataClusterName', $k3sArcDataClusterName, [System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('k3sArcClusterName', $k3sArcClusterName, [System.EnvironmentVariableTarget]::Machine)
+[System.Environment]::SetEnvironmentVariable('githubBranch', $githubBranch, [System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('githubUser', $githubUser, [System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('templateBaseUrl', $templateBaseUrl, [System.EnvironmentVariableTarget]::Machine)
 [System.Environment]::SetEnvironmentVariable('flavor', $flavor, [System.EnvironmentVariableTarget]::Machine)

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -113,7 +113,7 @@ New-Item -Path $Env:ArcBoxTestsDir -ItemType directory -Force
 
 Start-Transcript -Path $Env:ArcBoxLogsDir\Bootstrap.log
 
-if ([bool]$vmAutologon) {
+if ($vmAutologon -eq "true") {
 
     Write-Host "Configuring VM Autologon"
 
@@ -123,6 +123,10 @@ if ([bool]$vmAutologon) {
     if($flavor -eq "DataOps"){
         Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "DefaultDomainName" "jumpstart.local"
     }
+} else {
+
+    Write-Host "Not configuring VM Autologon"
+
 }
 
 # Set SyncForegroundPolicy to 1 to ensure that the scheduled task runs after the client VM joins the domain

--- a/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1
+++ b/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1
@@ -43,7 +43,7 @@ az k8s-configuration flux create `
     --cluster-type connectedClusters `
     --scope cluster `
     --url $appClonedRepo `
-    --branch main --sync-interval 3s `
+    --branch $Env:githubBranch --sync-interval 3s `
     --kustomization name=nginx path=./nginx/release
 
 # Create GitOps config for Hello-Arc application
@@ -105,7 +105,7 @@ foreach ($configName in $configs) {
 #   --password "arcbox" `
 #   --name $certname `
 #   --file "$Env:TempDir\$certname.pfx"
- 
+
 # Write-Host "Installing Azure Key Vault Kubernetes extension instance"
 # az k8s-extension create `
 #   --name 'akvsecretsprovider' `
@@ -129,17 +129,17 @@ foreach ($configName in $configs) {
 #   name: azure-kv-sync-tls
 # spec:
 #   provider: azure
-#   secretObjects:                       # secretObjects defines the desired state of synced K8s secret objects                                
+#   secretObjects:                       # secretObjects defines the desired state of synced K8s secret objects
 #   - secretName: ingress-tls-csi
 #     type: kubernetes.io/tls
-#     data: 
+#     data:
 #     - objectName: "$certname"
 #       key: tls.key
 #     - objectName: "$certname"
 #       key: tls.crt
 #   parameters:
 #     usePodIdentity: "false"
-#     keyvaultName: $Env:keyVaultName                        
+#     keyvaultName: $Env:keyVaultName
 #     objects: |
 #       array:
 #         - |
@@ -176,7 +176,7 @@ foreach ($configName in $configs) {
 #         volumeAttributes:
 #           secretProviderClass: "azure-kv-sync-tls"
 #         nodePublishSecretRef:
-#           name: secrets-store-creds  
+#           name: secrets-store-creds
 # "@
 
 # Write-Host "Deploying App referencing the secret"

--- a/azure_jumpstart_arcbox/artifacts/testDefenderForSQL.ps1
+++ b/azure_jumpstart_arcbox/artifacts/testDefenderForSQL.ps1
@@ -17,7 +17,7 @@ Import-Module $moduleFile
 Get-Command -Module SqlAdvancedThreatProtectionShell
 
 Write-Host "Executing SQL injection"
-$saPasswordEncrypted = ConvertTo-SecureString -String "ArcDemo123!!" -AsPlainText -Force
+$saPasswordEncrypted = ConvertTo-SecureString -String "JS123!!" -AsPlainText -Force
 Test-SqlAtpInjection -UserName sa -Password $saPasswordEncrypted # High risk
 Start-Sleep(30) # Wait between tests
 

--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -89,6 +89,9 @@ param deployBastion bool = false
 @description('User github account where they have forked https://github.com/microsoft/azure-arc-jumpstart-apps')
 param githubUser string
 
+@description('Git branch to use from the forked repo https://github.com/microsoft/azure-arc-jumpstart-apps')
+param githubBranch string
+
 @description('The name of the K3s cluster')
 param k3sArcClusterName string = '${namingPrefix}-K3s'
 
@@ -235,7 +238,7 @@ resource vmBootstrap 'Microsoft.Compute/virtualMachines/extensions@2022-03-01' =
       fileUris: [
         uri(templateBaseUrl, 'artifacts/Bootstrap.ps1')
       ]
-      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername ${windowsAdminUsername} -adminPassword ${windowsAdminPassword} -tenantId ${tenantId} -spnAuthority ${spnAuthority} -subscriptionId ${subscription().subscriptionId} -resourceGroup ${resourceGroup().name} -azdataUsername ${azdataUsername} -azdataPassword ${azdataPassword} -acceptEula ${acceptEula} -registryUsername ${registryUsername} -registryPassword ${registryPassword} -arcDcName ${arcDcName} -azureLocation ${location} -mssqlmiName ${mssqlmiName} -POSTGRES_NAME ${postgresName} -POSTGRES_WORKER_NODE_COUNT ${postgresWorkerNodeCount} -POSTGRES_DATASIZE ${postgresDatasize} -POSTGRES_SERVICE_TYPE ${postgresServiceType} -stagingStorageAccountName ${stagingStorageAccountName} -workspaceName ${workspaceName} -templateBaseUrl ${templateBaseUrl} -flavor ${flavor} -k3sArcDataClusterName ${k3sArcDataClusterName} -k3sArcClusterName ${k3sArcClusterName} -aksArcClusterName ${aksArcClusterName} -aksdrArcClusterName ${aksdrArcClusterName} -githubUser ${githubUser} -vmAutologon ${vmAutologon} -rdpPort ${rdpPort} -addsDomainName ${addsDomainName} -customLocationRPOID ${customLocationRPOID} -resourceTags ${resourceTags} -namingPrefix ${namingPrefix} -debugEnabled ${debugEnabled}'
+      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername ${windowsAdminUsername} -adminPassword ${windowsAdminPassword} -tenantId ${tenantId} -spnAuthority ${spnAuthority} -subscriptionId ${subscription().subscriptionId} -resourceGroup ${resourceGroup().name} -azdataUsername ${azdataUsername} -azdataPassword ${azdataPassword} -acceptEula ${acceptEula} -registryUsername ${registryUsername} -registryPassword ${registryPassword} -arcDcName ${arcDcName} -azureLocation ${location} -mssqlmiName ${mssqlmiName} -POSTGRES_NAME ${postgresName} -POSTGRES_WORKER_NODE_COUNT ${postgresWorkerNodeCount} -POSTGRES_DATASIZE ${postgresDatasize} -POSTGRES_SERVICE_TYPE ${postgresServiceType} -stagingStorageAccountName ${stagingStorageAccountName} -workspaceName ${workspaceName} -templateBaseUrl ${templateBaseUrl} -flavor ${flavor} -k3sArcDataClusterName ${k3sArcDataClusterName} -k3sArcClusterName ${k3sArcClusterName} -aksArcClusterName ${aksArcClusterName} -aksdrArcClusterName ${aksdrArcClusterName} -githubUser ${githubUser} -githubBranch ${githubBranch} -vmAutologon ${vmAutologon} -rdpPort ${rdpPort} -addsDomainName ${addsDomainName} -customLocationRPOID ${customLocationRPOID} -resourceTags ${resourceTags} -namingPrefix ${namingPrefix} -debugEnabled ${debugEnabled}'
     }
   }
 }

--- a/azure_jumpstart_arcbox/bicep/main.bicep
+++ b/azure_jumpstart_arcbox/bicep/main.bicep
@@ -146,6 +146,7 @@ module clientVmDeployment 'clientVm/clientVm.bicep' = {
     flavor: flavor
     subnetId: mgmtArtifactsAndPolicyDeployment.outputs.subnetId
     deployBastion: deployBastion
+    githubBranch: githubBranch
     githubUser: githubUser
     location: location
     k3sArcDataClusterName : k3sArcDataClusterName


### PR DESCRIPTION
This pull request introduces several updates to the `azure_jumpstart_arcbox` project, mainly focusing on adding a new parameter for the GitHub branch and improving the configuration logic. The most important changes include the addition of the `githubBranch` parameter across various scripts and templates, updates to environment variable settings, and enhancements to the VM autologon configuration.

### Parameter Addition:
* [`azure_jumpstart_arcbox/artifacts/Bootstrap.ps1`](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R28): Added `githubBranch` parameter to the script parameters and environment variable settings. [[1]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R28) [[2]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R61)
* [`azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep`](diffhunk://#diff-db7ddb891dea059a7a5630ee36842f00a9d7fa9e6e96a1873867bdcf3a7dda58R92-R94): Added `githubBranch` parameter to the Bicep template.
* [`azure_jumpstart_arcbox/bicep/main.bicep`](diffhunk://#diff-5a585802eb85810bd727cbf66096ef340c6617d731c97a8a4c200e3cca5e8231R149): Passed the `githubBranch` parameter to the `clientVmDeployment` module.

### Configuration Updates:
* [`azure_jumpstart_arcbox/artifacts/Bootstrap.ps1`](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707L116-R118): Enhanced VM autologon logic to check if the `vmAutologon` parameter is explicitly set to "true" and added a message for when autologon is not configured. [[1]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707L116-R118) [[2]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R128-R131)
* [`azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1`](diffhunk://#diff-770b4da0148c2b5f9fe459fa68ef7a33b2ed56a43e42557f24d3c235cfa0e59eL46-R46): Updated the GitOps configuration to use the new `githubBranch` environment variable.

### Miscellaneous:
* [`azure_jumpstart_arcbox/artifacts/testDefenderForSQL.ps1`](diffhunk://#diff-4aaede755c5bb5665e15d065008e25c0894bede0e3baacdd51906fc056c701c7L20-R20): Changed the hardcoded password for SQL injection testing.
* [`azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep`](diffhunk://#diff-db7ddb891dea059a7a5630ee36842f00a9d7fa9e6e96a1873867bdcf3a7dda58L238-R241): Updated the `commandToExecute` in the VM bootstrap configuration to include the `githubBranch` parameter.