### PR TITLE
Arcbox 3.0 - Bookstore Launch to show traffic splitting

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/BookStoreLaunch.ps1
+++ b/azure_jumpstart_arcbox/artifacts/BookStoreLaunch.ps1
@@ -1,2 +1,2 @@
-Start-Process -FilePath msedge -ArgumentList '--new-window http://arcbox.devops.com/bookbuyer http://arcbox.devops.com/bookstore http://arcbox.devops.com/bookstore-v2'
+Start-Process -FilePath msedge -ArgumentList '--new-window http://arcbox.devops.com/bookstore'
 [Environment]::Exit(1)


### PR DESCRIPTION
This PR removes the bookbuyer components that were displayed in Edge.  It will now be a single tab showing bookstore-v1 and bookstore-v2

<img width="928" alt="image" src="https://github.com/user-attachments/assets/f49ad40c-4a5d-48a9-a57b-2ad983dd119e">
