### PR TITLE
ArcBox 3.0 - Enable Windows Firewall rule for SQL Server

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -199,6 +199,9 @@ if ($Env:flavor -ne "DevOps") {
 
     }
 
+    # Enable Windows Firewall rule for SQL Server
+    Invoke-Command -VMName $SQLvmName -ScriptBlock { New-NetFirewallRule -DisplayName "Allow SQL Server TCP 1433" -Direction Inbound -Protocol TCP -LocalPort 1433 -Action Allow } -Credential $winCreds
+
     # Download SQL assessment preparation script
     Invoke-WebRequest ($Env:templateBaseUrl + "artifacts/prepareSqlServerForAssessment.ps1") -OutFile $nestedVMArcBoxDir\prepareSqlServerForAssessment.ps1
     Copy-VMFile $SQLvmName -SourcePath "$Env:ArcBoxDir\prepareSqlServerForAssessment.ps1" -DestinationPath "$nestedVMArcBoxDir\prepareSqlServerForAssessment.ps1" -CreateFullPath -FileSource Host -Force

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -131,8 +131,6 @@ if ($Env:flavor -ne "DevOps") {
         $folder.Attributes += [System.IO.FileAttributes]::Hidden
     }
 
-    $Env:AZURE_CONFIG_DIR = $cliDir.FullName
-
     # Install Azure CLI extensions
     Write-Header "Az CLI extensions"
 


### PR DESCRIPTION
This pull request includes several changes to the `azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1` file, focusing on improving the configuration and security setup for SQL Server. The most important changes include the removal of an environment variable setting and the addition of a firewall rule for SQL Server.

Configuration and security improvements:

* Removed the setting of the `AZURE_CONFIG_DIR` environment variable. (`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`)
* Added a command to enable a Windows Firewall rule for SQL Server, allowing inbound TCP traffic on port 1433. (`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`)