### PR TITLE
Refactor autoShutdown status logic to disable if no email is provided

### DIFF
--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -293,7 +293,7 @@ resource autoShutdown 'Microsoft.DevTestLab/schedules@2018-09-15' = if (autoShut
     }
     timeZoneId: autoShutdownTimezone
     notificationSettings: {
-      status: 'Enabled'
+      status: empty(autoShutdownEmailRecipient) ? 'Disabled' : 'Enabled' // Set status based on whether an email is provided
       timeInMinutes: 30
       webhookUrl: ''
       emailRecipient: autoShutdownEmailRecipient

--- a/azure_jumpstart_arcbox/bicep/main.bicep
+++ b/azure_jumpstart_arcbox/bicep/main.bicep
@@ -186,7 +186,7 @@ module clientVmDeployment 'clientVm/clientVm.bicep' = {
     autoShutdownEnabled: autoShutdownEnabled
     autoShutdownTime: autoShutdownTime
     autoShutdownTimezone: autoShutdownTimezone
-    autoShutdownEmailRecipient: autoShutdownEmailRecipient
+    autoShutdownEmailRecipient: empty(autoShutdownEmailRecipient) ? null : autoShutdownEmailRecipient
   }
   dependsOn: [
     updateVNetDNSServers


### PR DESCRIPTION
This pull request includes changes to the `azure_jumpstart_arcbox/bicep` files to enhance the handling of the auto-shutdown feature based on the presence of an email recipient. The most important changes involve conditional logic to enable or disable the auto-shutdown status and handle null values for the email recipient.

Improvements to auto-shutdown feature:

* [`azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep`](diffhunk://#diff-db7ddb891dea059a7a5630ee36842f00a9d7fa9e6e96a1873867bdcf3a7dda58L296-R296): Modified the `status` field to be conditionally set to 'Disabled' if no email recipient is provided, otherwise 'Enabled'.
* [`azure_jumpstart_arcbox/bicep/main.bicep`](diffhunk://#diff-5a585802eb85810bd727cbf66096ef340c6617d731c97a8a4c200e3cca5e8231L189-R189): Updated the `autoShutdownEmailRecipient` to be set to `null` if no email recipient is provided, using conditional logic.

- Fixes https://github.com/Azure/arc_jumpstart_docs/issues/404