### PR TITLE
Update WinGet.ps1 to install specific versions of Microsoft.WinGet.Client and Microsoft.WinGet.DSC

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/WinGet.ps1
+++ b/azure_jumpstart_arcbox/artifacts/WinGet.ps1
@@ -7,8 +7,9 @@ $logFilePath = Join-Path -Path $Env:ArcBoxLogsDir -ChildPath ('WinGet-provisioni
 
 Start-Transcript -Path $logFilePath -Force -ErrorAction SilentlyContinue
 
-# Install WinGet DSC resource - also installs Microsoft.WinGet.Client as implicit dependency
-Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Prerelease
+# Install WinGet PowerShell modules
+Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.8.1911
+Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Prerelease -Version 1.8.1911-alpha
 
 # Install DSC resources required for ArcBox
 Install-PSResource -Name DSCR_Font -Scope AllUsers -Quiet -AcceptLicense -TrustRepository


### PR DESCRIPTION
This pull request includes updates to the `WinGet.ps1` script to specify versions for the WinGet PowerShell modules and improve the installation process.

### Updates to WinGet PowerShell modules:

* [`azure_jumpstart_arcbox/artifacts/WinGet.ps1`](diffhunk://#diff-052ac08b482fd0b1856485ecfb9c7e5d4a40e265a0f80bced64db99e149edafdL10-R12): Updated the installation commands for `Microsoft.WinGet.Client` and `Microsoft.WinGet.DSC` to specify their versions (`1.8.1911` and `1.8.1911-alpha`, respectively).

- Fixes #2724 