### PR TITLE
Patch azure-iot-ops extension to use azure-identiy 1.17.1

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-manufacturing.psd1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-manufacturing.psd1
@@ -77,7 +77,7 @@
         'kubernetes-cli',
         'vcredist140',
         'microsoft-edge',
-        'azcopy10',
+        'azcopy10 --version=10.25.1',
         'vscode',
         'git',
         '7zip',

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-manufacturing.psd1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-manufacturing.psd1
@@ -77,7 +77,7 @@
         'kubernetes-cli',
         'vcredist140',
         'microsoft-edge',
-        'azcopy10 --version=10.25.1',
+        'azcopy10',
         'vscode',
         'git',
         '7zip',

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -175,6 +175,7 @@ if ($industry -eq "retail") {
 }
 
 if ($industry -eq "manufacturing") {
+    Update-AzureIoTOpsExtension
     Deploy-AIO
     Deploy-ManufacturingConfigs
     $mqttIpArray=Set-MQTTIpAddress

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/common.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/common.psm1
@@ -28,6 +28,11 @@ function Deploy-AzCLI {
         }
     }
 
+    # Patch azure-identity for azure-iot-ops
+    Write-Host "[$(Get-Date -Format t)] INFO: Patching azure-identity for azure-iot-ops" -ForegroundColor Gray
+    "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
+
+    Start-Sleep -Seconds 60
 
     Write-Host "[$(Get-Date -Format t)] INFO: Az CLI configuration complete!" -ForegroundColor Green
     Write-Host

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/common.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/common.psm1
@@ -28,14 +28,7 @@ function Deploy-AzCLI {
         }
     }
 
-    # Patch azure-identity for azure-iot-ops
-    Write-Host "[$(Get-Date -Format t)] INFO: Patching azure-identity for azure-iot-ops" -ForegroundColor Gray
-    "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
-
-    Start-Sleep -Seconds 60
-
     Write-Host "[$(Get-Date -Format t)] INFO: Az CLI configuration complete!" -ForegroundColor Green
-    Write-Host
 }
 
 function Deploy-AzPowerShell {

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
@@ -581,7 +581,7 @@ function Deploy-ManufacturingBookmarks {
 function Update-AzureIoTOpsExtension {
     try {
         Write-Host "Starting patching of azure-iot-ops extension..." -ForegroundColor Green
-        & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "& "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure-cli-extensions\azure-iot-ops" azure-identity==1.17.1
+        & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure-cli-extensions\azure-iot-ops" azure-identity==1.17.1
         if ($LASTEXITCODE -eq 0) {
             Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
         } else {

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
@@ -577,3 +577,18 @@ function Deploy-ManufacturingBookmarks {
     $quickAccess.Namespace($AgConfig.AgDirectories.AgDir).Self.InvokeVerb("pintohome")
     $quickAccess.Namespace($AgConfig.AgDirectories.AgLogsDir).Self.InvokeVerb("pintohome")
 }
+
+function Update-AzureIoTOpsExtension {
+    try {
+        Write-Host "Starting installation of azure-iot-ops extension..." -ForegroundColor Green
+        & "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
+        } else {
+            Write-Host "Installation of azure-iot-ops extension failed with exit code $LASTEXITCODE." -ForegroundColor Red
+        }
+    } catch {
+        Write-Host "An error occurred during the installation of azure-iot-ops extension." -ForegroundColor Red
+        Write-Host $_.Exception.Message -ForegroundColor Red
+    }
+}

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
@@ -580,7 +580,7 @@ function Deploy-ManufacturingBookmarks {
 
 function Update-AzureIoTOpsExtension {
     try {
-        Write-Host "Starting installation of azure-iot-ops extension..." -ForegroundColor Green
+        Write-Host "Starting patching of azure-iot-ops extension..." -ForegroundColor Green
         & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
         if ($LASTEXITCODE -eq 0) {
             Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
@@ -588,7 +588,7 @@ function Update-AzureIoTOpsExtension {
             Write-Host "Installation of azure-iot-ops extension failed with exit code $LASTEXITCODE." -ForegroundColor Red
         }
     } catch {
-        Write-Host "An error occurred during the installation of azure-iot-ops extension." -ForegroundColor Red
+        Write-Host "An error occurred during the patching of the azure-iot-ops extension." -ForegroundColor Red
         Write-Host $_.Exception.Message -ForegroundColor Red
     }
 }

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
@@ -581,7 +581,7 @@ function Deploy-ManufacturingBookmarks {
 function Update-AzureIoTOpsExtension {
     try {
         Write-Host "Starting installation of azure-iot-ops extension..." -ForegroundColor Green
-        & "C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
+        & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
         if ($LASTEXITCODE -eq 0) {
             Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
         } else {

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
@@ -581,10 +581,9 @@ function Deploy-ManufacturingBookmarks {
 function Update-AzureIoTOpsExtension {
     try {
         Write-Host "Starting patching of azure-iot-ops extension..." -ForegroundColor Green
-        & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
+        & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "& "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure-cli-extensions\azure-iot-ops" azure-identity==1.17.1
         if ($LASTEXITCODE -eq 0) {
             Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
-            Start-Sleep -Seconds 60
         } else {
             Write-Host "Installation of azure-iot-ops extension failed with exit code $LASTEXITCODE." -ForegroundColor Red
         }

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
@@ -581,7 +581,7 @@ function Deploy-ManufacturingBookmarks {
 function Update-AzureIoTOpsExtension {
     try {
         Write-Host "Starting patching of azure-iot-ops extension..." -ForegroundColor Green
-        & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure-cli-extensions\azure-iot-ops" azure-identity==1.17.1
+        & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure-cli-extensions\azure-iot-ops" azure-identity==1.17.1
         if ($LASTEXITCODE -eq 0) {
             Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
         } else {

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/manufacturing.psm1
@@ -584,6 +584,7 @@ function Update-AzureIoTOpsExtension {
         & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "$env:USERPROFILE/.azure/cliextensions/azure-iot-ops" azure-identity==1.17.1
         if ($LASTEXITCODE -eq 0) {
             Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
+            Start-Sleep -Seconds 60
         } else {
             Write-Host "Installation of azure-iot-ops extension failed with exit code $LASTEXITCODE." -ForegroundColor Red
         }


### PR DESCRIPTION
This PR addresses the issues with the version of azure-identity used in the azure-iot-ops extension identified in #2731 and #2378.  It introduces a function Update-AzureIoTOpsExtension to patch azure-identity.