### PR TITLE
Fix azure-iot-ops 0.5.1b1 extension issue with azure-identity

### DIFF
--- a/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/LogonScript.ps1
+++ b/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/LogonScript.ps1
@@ -400,6 +400,28 @@ catch {
 Write-Host "`n"
 Write-Host "[$(Get-Date -Format t)] INFO: Installing the Azure IoT Ops CLI extension" -ForegroundColor DarkGray
 Write-Host "`n"
+
+##############################################################
+# Patching Azure IoT Ops Extension
+##############################################################
+Write-Host "`n"
+Write-Host "[$(Get-Date -Format t)] INFO: Patching the Azure IoT Ops CLI extension" -ForegroundColor DarkGray
+try {
+    Write-Host "Starting patching of azure-iot-ops extension..." -ForegroundColor Green
+    & "C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe" -m pip install -U --target "C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\azure-cli-extensions\azure-iot-ops" azure-identity==1.17.1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Installation of azure-iot-ops extension completed successfully." -ForegroundColor Green
+    } else {
+        Write-Host "Installation of azure-iot-ops extension failed with exit code $LASTEXITCODE." -ForegroundColor Red
+    }
+} catch {
+    Write-Host "An error occurred during the patching of the azure-iot-ops extension." -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+}
+Write-Host "`n"
+
+
+
 ##############################################################
 # Deploy aio
 ##############################################################


### PR DESCRIPTION
this PR addresses the issue (noted in #2738) with "cannot import name 'AccessTokenInfo' from 'azure.core.credentials' when deploying AIO on the cluster" from the azure-iot-ops extension.  Note that part of the pip install will display the following, but it is expected and does not impact the success of the deployment:

"ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
pyopenssl 24.0.0 requires cryptography<43,>=41.0.5, but you have cryptography 43.0.1 which is incompatible."