### PR TITLE
ArcBox - refactor GitOps script for updated repository URL

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1
+++ b/azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1
@@ -12,7 +12,7 @@ $ingressNamespace = "ingress-nginx"
 
 $certdns = "arcbox.k3sdevops.com"
 
-$appClonedRepo = "https://github.com/$Env:githubUser/azure-arc-jumpstart-apps"
+$appClonedRepo = "https://github.com/$Env:githubUser/jumpstart-apps"
 
 Start-Transcript -Path $Env:ArcBoxLogsDir\K3sGitOps.log
 
@@ -56,7 +56,7 @@ az k8s-configuration flux create `
     --scope namespace `
     --url $appClonedRepo `
     --branch $env:githubBranch --sync-interval 3s `
-    --kustomization name=helloarc path=./hello-arc/yaml
+    --kustomization name=helloarc path=./arcbox/hello_arc/yaml
 
 $configs = $(az k8s-configuration flux list --cluster-name $Env:k3sArcClusterName --cluster-type connectedClusters --resource-group $Env:resourceGroup --query "[].name" -otsv)
 


### PR DESCRIPTION
This pull request includes changes to the `azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1` file, primarily focusing on updating repository URLs and file paths.

Repository URL update:

* Changed the repository URL from `https://github.com/$Env:githubUser/azure-arc-jumpstart-apps` to `https://github.com/$Env:githubUser/jumpstart-apps` to reflect the new repository location. (`[azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1L15-R15](diffhunk://#diff-770b4da0148c2b5f9fe459fa68ef7a33b2ed56a43e42557f24d3c235cfa0e59eL15-R15)`)

File path update:

* Modified the kustomization path from `./hello-arc/yaml` to `./arcbox/hello_arc/yaml` in the `az k8s-configuration flux create` command to match the updated directory structure. (`[azure_jumpstart_arcbox/artifacts/gitops_scripts/K3sGitOps.ps1L59-R59](diffhunk://#diff-770b4da0148c2b5f9fe459fa68ef7a33b2ed56a43e42557f24d3c235cfa0e59eL59-R59)`)