### PR TITLE
Pin-down Az.ConnectedKubernetes due to regression

### DIFF
--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full/bicep_template/artifacts/LogonScript.ps1
@@ -118,7 +118,7 @@ New-NetIPAddress -IPAddress "172.20.1.1" -PrefixLength 24 -InterfaceIndex $ifInd
 New-NetNat -Name "AKS-Int" -InternalIPInterfaceAddressPrefix "172.20.1.0/24"
 
 ############################################
-# Deploying the nested L1 virtual machines 
+# Deploying the nested L1 virtual machines
 ############################################
 Write-Host "INFO: Fetching Windows 11 IoT Enterprise VM images from Azure storage. This may take a few minutes." -ForegroundColor Green
 azcopy cp $vhdxUri "C:\VHDX\base.vhdx" --recursive=true --check-length=false --log-level=ERROR
@@ -175,7 +175,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
         # Create diff disks for each site host
         Write-Host "INFO: Creating differencing disk for site $($site.Name)" -ForegroundColor Gray
         $vhd = New-VHD -ParentPath $vhdxPath -Path "C:\VHDX\$($site.Name)DiffDisk.vhdx" -Differencing
-        
+
         # Create a new virtual machine and attach the existing virtual hard disk
         Write-Host "INFO: Creating and configuring $($site.Name) virtual machine." -ForegroundColor Gray
         New-VM -Name $site.Name `
@@ -184,7 +184,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
             -VHDPath $vhd.Path `
             -Generation 2 `
             -Switch "AKS-Int"
-        
+
         # Set up the virtual machine before coping all AKS Edge Essentials automation files
         Set-VMProcessor -VMName $site.Name `
             -Count 4 `
@@ -192,7 +192,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
 
         Get-VMNetworkAdapter -VMName $site.Name | Set-VMNetworkAdapter -MacAddressSpoofing On
         Enable-VMIntegrationService -VMName $site.Name -Name "Guest Service Interface"
-  
+
         # Start the virtual machine
         Start-VM -Name $site.Name
     }
@@ -201,7 +201,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
 Start-Sleep -Seconds 20
 
 ########################################################################
-# Prepare L1 nested virtual machines for AKS Edge Essentials bootstrap 
+# Prepare L1 nested virtual machines for AKS Edge Essentials bootstrap
 ########################################################################
 foreach ($site in $SiteConfig.GetEnumerator()) {
     if ($site.Value.Type -eq "AKSEE") {
@@ -213,7 +213,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
         }
     }
 }
-# Create an array with VM names    
+# Create an array with VM names
 $VMnames = (Get-VM).Name
 
 Start-Sleep -Seconds 60 # Give some time after restart
@@ -224,7 +224,7 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
     $hostname = hostname
     $ProgressPreference = "SilentlyContinue"
     ###########################################
-    # Preparing environment folders structure 
+    # Preparing environment folders structure
     ###########################################
     Write-Host "INFO: Preparing folder structure on $hostname." -ForegroundColor Gray
     $deploymentFolder = "C:\Deployment" # Deployment folder is already pre-created in the VHD image
@@ -252,7 +252,7 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
     $AKSEEPinnedSchemaVersion = $using:AKSEEPinnedSchemaVersion
 
     ##########################################
-    # Deploying AKS Edge Essentials clusters 
+    # Deploying AKS Edge Essentials clusters
     ##########################################
     $deploymentFolder = "C:\Deployment" # Deployment folder is already pre-created in the VHD image
     $logsFolder = "$deploymentFolder\Logs"
@@ -277,7 +277,7 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
         Start-Sleep -Seconds 5
         $timeElapsed = $timeElapsed + 10
     } until ((Test-Connection bing.com -Count 1 -ErrorAction SilentlyContinue) -or ($timeElapsed -eq 60))
-      
+
     # Fetching latest AKS Edge Essentials msi file
     Write-Host "INFO: Fetching latest AKS Edge Essentials install file on $hostname." -ForegroundColor Gray
 
@@ -361,7 +361,7 @@ Write-Host
 Write-Host "[$(Get-Date -Format t)] INFO: Installing AKS Edge Essentials" -ForegroundColor DarkGreen
 $Session = New-PSSession -VMName Node1 -Credential $Credentials
 Write-Host "INFO: Rebooting Node1." -ForegroundColor Gray
-Invoke-Command -Session $Session -ScriptBlock { 
+Invoke-Command -Session $Session -ScriptBlock {
     $Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -File C:\Deployment\AKSEEBootstrap.ps1"
     $Trigger = New-ScheduledTaskTrigger -AtStartup
     Register-ScheduledTask -TaskName "Startup Scan" -Action $Action -Trigger $Trigger -User $env:USERNAME -Password $using:hypervVMPassword -RunLevel Highest
@@ -380,7 +380,7 @@ $elapsedTime = Measure-Command {
     $user = "Administrator"
     [securestring]$secStringPassword = ConvertTo-SecureString 'JS123!!' -AsPlainText -Force
     $Credential = New-Object System.Management.Automation.PSCredential($user, $secStringPassword)
-    while (!(Invoke-Command -VMName "Node1" -Credential $Credential -ScriptBlock { Test-Path $using:path })) { 
+    while (!(Invoke-Command -VMName "Node1" -Credential $Credential -ScriptBlock { Test-Path $using:path })) {
         Start-Sleep 30
         Write-Host "INFO: Waiting for AKS Edge Essentials kubeconfig to be available on Node1." -ForegroundColor Gray
     }
@@ -462,7 +462,7 @@ Invoke-Command -VMName "Node2" -Credential $Credentials -ScriptBlock {
 
 $Session = New-PSSession -VMName Node2 -Credential $Credentials
 Write-Host "INFO: Rebooting Node2." -ForegroundColor Gray
-Invoke-Command -Session $Session -ScriptBlock { 
+Invoke-Command -Session $Session -ScriptBlock {
     $Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -File C:\Deployment\AKSEEBootstrap.ps1"
     $Trigger = New-ScheduledTaskTrigger -AtStartup
     Register-ScheduledTask -TaskName "Startup Scan" -Action $Action -Trigger $Trigger -User $env:USERNAME -Password $using:hypervVMPassword -RunLevel Highest
@@ -486,9 +486,10 @@ Invoke-Command -VMName "Node1" -Credential $Credentials -ScriptBlock {
     $hostname = hostname
     $ProgressPreference = "SilentlyContinue"
     Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-    Install-Module Az.Resources -Repository PSGallery -Force -AllowClobber -ErrorAction Stop  
-    Install-Module Az.Accounts -Repository PSGallery -Force -AllowClobber -ErrorAction Stop 
-    Install-Module Az.ConnectedKubernetes -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
+    Install-Module Az.Resources -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
+    Install-Module Az.Accounts -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
+    # Temporary pin-down due to regression: https://github.com/microsoft/azure_arc/pull/2762
+    Install-Module Az.ConnectedKubernetes -Repository PSGallery -Force -AllowClobber -ErrorAction Stop -RequiredVersion 0.10.3
 
     # Connect to Arc
     $deploymentPath = "C:\Deployment\config.json"
@@ -563,22 +564,22 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
 
 # Changing to Client VM wallpaper
 $imgPath = "C:\Temp\wallpaper.png"
-$code = @' 
-using System.Runtime.InteropServices; 
-namespace Win32{ 
-    
-     public class Wallpaper{ 
-        [DllImport("user32.dll", CharSet=CharSet.Auto)] 
-         static extern int SystemParametersInfo (int uAction , int uParam , string lpvParam , int fuWinIni) ; 
-         
-         public static void SetWallpaper(string thePath){ 
-            SystemParametersInfo(20,0,thePath,3); 
+$code = @'
+using System.Runtime.InteropServices;
+namespace Win32{
+
+     public class Wallpaper{
+        [DllImport("user32.dll", CharSet=CharSet.Auto)]
+         static extern int SystemParametersInfo (int uAction , int uParam , string lpvParam , int fuWinIni) ;
+
+         public static void SetWallpaper(string thePath){
+            SystemParametersInfo(20,0,thePath,3);
          }
     }
- } 
+ }
 '@
 
-add-type $code 
+add-type $code
 [Win32.Wallpaper]::SetWallpaper($imgPath)
 
 # Kill the open PowerShell monitoring kubectl get pods

--- a/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/LogonScript.ps1
+++ b/azure_arc_k8s_jumpstart/aks_hybrid/aks_edge_essentials_full_akri/bicep_template/artifacts/LogonScript.ps1
@@ -122,7 +122,7 @@ New-NetIPAddress -IPAddress "172.20.1.1" -PrefixLength 24 -InterfaceIndex $ifInd
 New-NetNat -Name "AKS-Int" -InternalIPInterfaceAddressPrefix "172.20.1.0/24"
 
 ############################################
-# Deploying the nested L1 virtual machines 
+# Deploying the nested L1 virtual machines
 ############################################
 Write-Host "INFO: Fetching Windows 11 IoT Enterprise VM images from Azure storage. This may take a few minutes." -ForegroundColor Green
 azcopy cp $vhdxUri "C:\VHDX\base.vhdx" --recursive=true --check-length=false --log-level=ERROR
@@ -179,7 +179,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
         # Create diff disks for each site host
         Write-Host "INFO: Creating differencing disk for site $($site.Name)" -ForegroundColor Gray
         $vhd = New-VHD -ParentPath $vhdxPath -Path "C:\VHDX\$($site.Name)DiffDisk.vhdx" -Differencing
-        
+
         # Create a new virtual machine and attach the existing virtual hard disk
         Write-Host "INFO: Creating and configuring $($site.Name) virtual machine." -ForegroundColor Gray
         New-VM -Name $site.Name `
@@ -188,7 +188,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
             -VHDPath $vhd.Path `
             -Generation 2 `
             -Switch "AKS-Int"
-        
+
         # Set up the virtual machine before coping all AKS Edge Essentials automation files
         Set-VMProcessor -VMName $site.Name `
             -Count 4 `
@@ -196,7 +196,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
 
         Get-VMNetworkAdapter -VMName $site.Name | Set-VMNetworkAdapter -MacAddressSpoofing On
         Enable-VMIntegrationService -VMName $site.Name -Name "Guest Service Interface"
-  
+
         # Start the virtual machine
         Start-VM -Name $site.Name
     }
@@ -205,7 +205,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
 Start-Sleep -Seconds 20
 
 ########################################################################
-# Prepare L1 nested virtual machines for AKS Edge Essentials bootstrap 
+# Prepare L1 nested virtual machines for AKS Edge Essentials bootstrap
 ########################################################################
 foreach ($site in $SiteConfig.GetEnumerator()) {
     if ($site.Value.Type -eq "AKSEE") {
@@ -217,7 +217,7 @@ foreach ($site in $SiteConfig.GetEnumerator()) {
         }
     }
 }
-# Create an array with VM names    
+# Create an array with VM names
 $VMnames = (Get-VM).Name
 
 Start-Sleep -Seconds 60 # Give some time after restart
@@ -228,7 +228,7 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
     $hostname = hostname
     $ProgressPreference = "SilentlyContinue"
     ###########################################
-    # Preparing environment folders structure 
+    # Preparing environment folders structure
     ###########################################
     Write-Host "INFO: Preparing folder structure on $hostname." -ForegroundColor Gray
     $deploymentFolder = "C:\Deployment" # Deployment folder is already pre-created in the VHD image
@@ -255,7 +255,7 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
     $AKSEEPinnedSchemaVersion = $using:AKSEEPinnedSchemaVersion
 
     ##########################################
-    # Deploying AKS Edge Essentials clusters 
+    # Deploying AKS Edge Essentials clusters
     ##########################################
     $deploymentFolder = "C:\Deployment" # Deployment folder is already pre-created in the VHD image
     $logsFolder = "$deploymentFolder\Logs"
@@ -280,7 +280,7 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
         Start-Sleep -Seconds 5
         $timeElapsed = $timeElapsed + 10
     } until ((Test-Connection bing.com -Count 1 -ErrorAction SilentlyContinue) -or ($timeElapsed -eq 60))
-      
+
     # Fetching latest AKS Edge Essentials msi file
     Write-Host "INFO: Fetching latest AKS Edge Essentials install file on $hostname." -ForegroundColor Gray
 
@@ -364,7 +364,7 @@ Write-Host
 Write-Host "[$(Get-Date -Format t)] INFO: Installing AKS Edge Essentials" -ForegroundColor DarkGreen
 $Session = New-PSSession -VMName Node1 -Credential $Credentials
 Write-Host "INFO: Rebooting Node1." -ForegroundColor Gray
-Invoke-Command -Session $Session -ScriptBlock { 
+Invoke-Command -Session $Session -ScriptBlock {
     $Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -File C:\Deployment\AKSEEBootstrap.ps1"
     $Trigger = New-ScheduledTaskTrigger -AtStartup
     Register-ScheduledTask -TaskName "Startup Scan" -Action $Action -Trigger $Trigger -User $env:USERNAME -Password $using:hypervVMPassword -RunLevel Highest
@@ -383,7 +383,7 @@ $elapsedTime = Measure-Command {
     $user = "Administrator"
     [securestring]$secStringPassword = ConvertTo-SecureString 'JS123!!' -AsPlainText -Force
     $Credential = New-Object System.Management.Automation.PSCredential($user, $secStringPassword)
-    while (!(Invoke-Command -VMName "Node1" -Credential $Credential -ScriptBlock { Test-Path $using:path })) { 
+    while (!(Invoke-Command -VMName "Node1" -Credential $Credential -ScriptBlock { Test-Path $using:path })) {
         Start-Sleep 30
         Write-Host "INFO: Waiting for AKS Edge Essentials kubeconfig to be available on Node1." -ForegroundColor Gray
     }
@@ -465,7 +465,7 @@ Invoke-Command -VMName "Node2" -Credential $Credentials -ScriptBlock {
 
 $Session = New-PSSession -VMName Node2 -Credential $Credentials
 Write-Host "INFO: Rebooting Node2." -ForegroundColor Gray
-Invoke-Command -Session $Session -ScriptBlock { 
+Invoke-Command -Session $Session -ScriptBlock {
     $Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-ExecutionPolicy Bypass -File C:\Deployment\AKSEEBootstrap.ps1"
     $Trigger = New-ScheduledTaskTrigger -AtStartup
     Register-ScheduledTask -TaskName "Startup Scan" -Action $Action -Trigger $Trigger -User $env:USERNAME -Password $using:hypervVMPassword -RunLevel Highest
@@ -489,9 +489,10 @@ Invoke-Command -VMName "Node1" -Credential $Credentials -ScriptBlock {
     $hostname = hostname
     $ProgressPreference = "SilentlyContinue"
     Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-    Install-Module Az.Resources -Repository PSGallery -Force -AllowClobber -ErrorAction Stop  
-    Install-Module Az.Accounts -Repository PSGallery -Force -AllowClobber -ErrorAction Stop 
-    Install-Module Az.ConnectedKubernetes -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
+    Install-Module Az.Resources -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
+    Install-Module Az.Accounts -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
+    # Temporary pin-down due to regression: https://github.com/microsoft/azure_arc/pull/2762
+    Install-Module Az.ConnectedKubernetes -Repository PSGallery -Force -AllowClobber -ErrorAction Stop -RequiredVersion 0.10.3
 
     # Connect to Arc
     $deploymentPath = "C:\Deployment\config.json"
@@ -566,22 +567,22 @@ Invoke-Command -VMName $VMnames -Credential $Credentials -ScriptBlock {
 
 # Changing to Client VM wallpaper
 $imgPath = "C:\Temp\wallpaper.png"
-$code = @' 
-using System.Runtime.InteropServices; 
-namespace Win32{ 
-    
-     public class Wallpaper{ 
-        [DllImport("user32.dll", CharSet=CharSet.Auto)] 
-         static extern int SystemParametersInfo (int uAction , int uParam , string lpvParam , int fuWinIni) ; 
-         
-         public static void SetWallpaper(string thePath){ 
-            SystemParametersInfo(20,0,thePath,3); 
+$code = @'
+using System.Runtime.InteropServices;
+namespace Win32{
+
+     public class Wallpaper{
+        [DllImport("user32.dll", CharSet=CharSet.Auto)]
+         static extern int SystemParametersInfo (int uAction , int uParam , string lpvParam , int fuWinIni) ;
+
+         public static void SetWallpaper(string thePath){
+            SystemParametersInfo(20,0,thePath,3);
          }
     }
- } 
+ }
 '@
 
-add-type $code 
+add-type $code
 [Win32.Wallpaper]::SetWallpaper($imgPath)
 
 # Kill the open PowerShell monitoring kubectl get pods
@@ -632,7 +633,7 @@ New-Item -Path $videoDir -ItemType directory -Force
 Invoke-WebRequest ($templateBaseUrl + "artifacts/video/video-streaming.yaml") -OutFile $videoDir\video-streaming.yaml
 Invoke-WebRequest ($templateBaseUrl + "artifacts/video/akri-video-streaming-app.yaml") -OutFile $videoDir\akri-video-streaming-app.yaml
 kubectl apply -f $videoDir\akri-video-streaming-app.yaml
-kubectl apply -f $videoDir\video-streaming.yaml  
+kubectl apply -f $videoDir\video-streaming.yaml
 
 # Removing the LogonScript Scheduled Task so it won't run on next reboot
 Unregister-ScheduledTask -TaskName "LogonScript" -Confirm:$false

--- a/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/LogonScript.ps1
+++ b/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/LogonScript.ps1
@@ -240,6 +240,8 @@ if ($aioConfig.PowerShellModules.Count -ne 0) {
     foreach ($module in $aioConfig.PowerShellModules) {
         Install-Module -Name $module -Force -Confirm:$false
     }
+    # Temporary pin-down due to regression: https://github.com/microsoft/azure_arc/pull/2762
+    Install-Module Az.ConnectedKubernetes -Repository PSGallery -Force -AllowClobber -ErrorAction Stop -RequiredVersion 0.10.3
 }
 
 # Register Azure providers
@@ -720,22 +722,22 @@ $quickAccess.Namespace($aioConfig.aioDirectories.aioLogsDir).Self.InvokeVerb("pi
 
 # Changing to Client VM wallpaper
 $imgPath = Join-Path $aioConfig.aioDirectories["aioDir"] "wallpaper.png"
-$code = @' 
-using System.Runtime.InteropServices; 
-namespace Win32{ 
-    
-     public class Wallpaper{ 
-        [DllImport("user32.dll", CharSet=CharSet.Auto)] 
-         static extern int SystemParametersInfo (int uAction , int uParam , string lpvParam , int fuWinIni) ; 
-         
-         public static void SetWallpaper(string thePath){ 
-            SystemParametersInfo(20,0,thePath,3); 
+$code = @'
+using System.Runtime.InteropServices;
+namespace Win32{
+
+     public class Wallpaper{
+        [DllImport("user32.dll", CharSet=CharSet.Auto)]
+         static extern int SystemParametersInfo (int uAction , int uParam , string lpvParam , int fuWinIni) ;
+
+         public static void SetWallpaper(string thePath){
+            SystemParametersInfo(20,0,thePath,3);
          }
     }
- } 
+ }
 '@
 
-add-type $code 
+add-type $code
 [Win32.Wallpaper]::SetWallpaper($imgPath)
 
 # Kill the open PowerShell monitoring kubectl get pods

--- a/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/aioConfig.psd1
+++ b/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/PowerShell/aioConfig.psd1
@@ -59,7 +59,7 @@
 
     # PowerShell modules
     PowerShellModules       = @(
-        'Az.ConnectedKubernetes',
+        #'Az.ConnectedKubernetes',
         'Az.KubernetesConfiguration',
         'Az.Kusto',
         'Az.EventGrid',

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/common.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/common.psm1
@@ -623,7 +623,7 @@ function Deploy-AzArcK8s {
             Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
             Install-Module Az.Resources -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
             Install-Module Az.Accounts -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
-            Install-Module Az.ConnectedKubernetes -Repository PSGallery -Force -AllowClobber -ErrorAction Stop
+            Install-Module Az.ConnectedKubernetes -Repository PSGallery -Force -AllowClobber -ErrorAction Stop -RequiredVersion 0.10.3
             Install-Module Az.ConnectedMachine -Force -AllowClobber -ErrorAction Stop
 
             # Connect servers to Arc
@@ -794,7 +794,7 @@ function Deploy-Workbook ($workbookFileName) {
     $updatedContent = $content -replace 'rg-placeholder', $resourceGroup
     $updatedContent = $updatedContent -replace'/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/xxxx/providers/Microsoft.OperationalInsights/workspaces/xxxx', "/subscriptions/$($subscriptionId)/resourceGroups/$($Env:resourceGroup)/providers/Microsoft.OperationalInsights/workspaces/$($Env:workspaceName)"
     $updatedContent = $updatedContent -replace'/subscriptions/00000000-0000-0000-0000-000000000000', "/subscriptions/$($subscriptionId)"
-    
+
     # Write the updated content back to the file
     Set-Content -Path $workbookTemplateFilePath -Value $updatedContent
     # Deploy the workbook


### PR DESCRIPTION
This pull request includes a small but crucial change to the `Deploy-AzArcK8s` function in the `common.psm1` file. The change specifies the required version of the `Az.ConnectedKubernetes` module to ensure compatibility and stability.

* [`azure_jumpstart_ag/artifacts/PowerShell/Modules/common.psm1`](diffhunk://#diff-a320dc7d665d4f7bde3e5b803d77f805945fcb552a2d366ae2da4dad2806c248L626-R626): Modified the `Deploy-AzArcK8s` function to install `Az.ConnectedKubernetes` module with a specific required version `0.10.3`.

Fixes #2761 