### PR TITLE
Migrate Contoso Bakeries to MCR

### DIFF
--- a/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/Settings/mqtt_listener.yml
+++ b/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/Settings/mqtt_listener.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: mqtt-listener
-        image: jumpstartprod.azurecr.io/contoso-bakeries-mqtt-listener:latest
+        image: mcr.microsoft.com/jumpstart/scenarios/mqtt_listener:1.0.0
         resources:
           limits:
             memory: "512Mi"

--- a/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/Settings/mqtt_simulator.yml
+++ b/azure_edge_iot_ops_jumpstart/aio_manufacturing/bicep/artifacts/Settings/mqtt_simulator.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: mqtt-simulator
-          image: jumpstartprod.azurecr.io/contoso-bakeries-mqtt-simulator:latest
+          image: mcr.microsoft.com/jumpstart/scenarios/mqtt_simulator:1.0.0
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
Migrating the `mqtt-simulator` and `mqtt-listener` containers to MCR for anonymous pull