### PR TITLE
Agora 2.0 enhancements

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -288,6 +288,26 @@ if($scenario -eq "contoso_supermarket"){
     Get-Job -name images-cache-cleanup | Remove-Job
 }
 
+# Create desktop shortcut for Logs-folder
+$WshShell = New-Object -comObject WScript.Shell
+$LogsPath = "C:\Ag\Logs"
+$Shortcut = $WshShell.CreateShortcut("$Env:USERPROFILE\Desktop\Logs.lnk")
+$Shortcut.TargetPath = $LogsPath
+$shortcut.WindowStyle = 3
+$shortcut.Save()
+
+# Configure Windows Terminal as the default terminal application
+$registryPath = "HKCU:\Console\%%Startup"
+
+if (Test-Path $registryPath) {
+    Set-ItemProperty -Path $registryPath -Name "DelegationConsole" -Value "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}"
+    Set-ItemProperty -Path $registryPath -Name "DelegationTerminal" -Value "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}"
+} else {
+    New-Item -Path $registryPath -Force | Out-Null
+    Set-ItemProperty -Path $registryPath -Name "DelegationConsole" -Value "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}"
+    Set-ItemProperty -Path $registryPath -Name "DelegationTerminal" -Value "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}"
+}
+
 
 # Removing the LogonScript Scheduled Task
 Write-Host "[$(Get-Date -Format t)] INFO: Removing scheduled logon task so it won't run on next login." -ForegroundColor Gray

--- a/azure_jumpstart_ag/artifacts/PowerShell/tests/Invoke-Test.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/tests/Invoke-Test.ps1
@@ -2,7 +2,6 @@
 
 $AgConfig = Import-PowerShellDataFile -Path $Env:AgConfigPath
 $AgTestsDir = $AgConfig.AgDirectories["AgTestsDir"]
-
 Invoke-Pester -Path "$AgTestsDir\common.tests.ps1" -Output Detailed -PassThru -OutVariable tests_common
 $tests_passed = $tests_common.Passed.Count
 $tests_failed = $tests_common.Failed.Count
@@ -20,3 +19,49 @@ Set-Content "$Env:windir\TEMP\agora-tests-succeeded.txt" $tests_passed
 Set-Content "$Env:windir\TEMP\agora-tests-failed.txt" $tests_failed
 
 bginfo.exe $AgTestsDir\ag-bginfo.bgi /timer:0 /NOLICPROMPT
+
+
+$DeploymentStatusPath = "C:\Ag\Logs\DeploymentStatus.log"
+
+Write-Header "Exporting deployment test results to $DeploymentStatusPath"
+
+Write-Output "`n" | Out-File -FilePath $DeploymentStatusPath
+
+$asciiArt = @"
+██████╗ ███████╗██████╗ ██╗      ██████╗ ██╗   ██╗███╗   ███╗███████╗███╗   ██╗████████╗    ███████╗████████╗ █████╗ ████████╗██╗   ██╗███████╗
+██╔══██╗██╔════╝██╔══██╗██║     ██╔═══██╗╚██╗ ██╔╝████╗ ████║██╔════╝████╗  ██║╚══██╔══╝    ██╔════╝╚══██╔══╝██╔══██╗╚══██╔══╝██║   ██║██╔════╝
+██║  ██║█████╗  ██████╔╝██║     ██║   ██║ ╚████╔╝ ██╔████╔██║█████╗  ██╔██╗ ██║   ██║       ███████╗   ██║   ███████║   ██║   ██║   ██║███████╗
+██║  ██║██╔══╝  ██╔═══╝ ██║     ██║   ██║  ╚██╔╝  ██║╚██╔╝██║██╔══╝  ██║╚██╗██║   ██║       ╚════██║   ██║   ██╔══██║   ██║   ██║   ██║╚════██║
+██████╔╝███████╗██║     ███████╗╚██████╔╝   ██║   ██║ ╚═╝ ██║███████╗██║ ╚████║   ██║       ███████║   ██║   ██║  ██║   ██║   ╚██████╔╝███████║
+╚═════╝ ╚══════╝╚═╝     ╚══════╝ ╚═════╝    ╚═╝   ╚═╝     ╚═╝╚══════╝╚═╝  ╚═══╝   ╚═╝       ╚══════╝   ╚═╝   ╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚══════╝
+"@
+
+Write-Output $asciiArt | Out-File -FilePath $DeploymentStatusPath -Append
+
+Write-Output "`nTests succeeded: $tests_passed" | Out-File -FilePath $DeploymentStatusPath -Append
+Write-Output "Tests failed: $tests_failed`n" | Out-File -FilePath $DeploymentStatusPath -Append
+
+Write-Output "To get an updated deployment status, open Windows Terminal and run:" | Out-File -FilePath $DeploymentStatusPath -Append
+Write-Output "C:\Ag\Tests\Invoke-Test.ps1`n" | Out-File -FilePath $DeploymentStatusPath -Append
+
+Write-Output "Failed:" | Out-File -FilePath $DeploymentStatusPath -Append
+$tests_common.Failed | Out-File -FilePath $DeploymentStatusPath -Append
+$tests_k8s.Failed | Out-File -FilePath $DeploymentStatusPath -Append
+
+Write-Output "Passed:" | Out-File -FilePath $DeploymentStatusPath -Append
+$tests_k8s.Passed | Out-File -FilePath $DeploymentStatusPath -Append
+$tests_common.Passed | Out-File -FilePath $DeploymentStatusPath -Append
+
+Write-Header "Exporting deployment test results to resource group tag DeploymentStatus"
+
+$DeploymentStatusString = "Tests succeeded: $tests_passed Tests failed: $tests_failed"
+
+$tags = Get-AzResourceGroup -Name $env:resourceGroup | Select-Object -ExpandProperty Tags
+
+if ($null -ne $tags) {
+    $tags["DeploymentStatus"] = $DeploymentStatusString
+} else {
+    $tags = @{"DeploymentStatus" = $DeploymentStatusString}
+}
+
+$null = Set-AzResourceGroup -ResourceGroupName $env:resourceGroup -Tag $tags

--- a/azure_jumpstart_ag/artifacts/PowerShell/tests/Invoke-Test.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/tests/Invoke-Test.ps1
@@ -25,18 +25,7 @@ $DeploymentStatusPath = "C:\Ag\Logs\DeploymentStatus.log"
 
 Write-Header "Exporting deployment test results to $DeploymentStatusPath"
 
-Write-Output "`n" | Out-File -FilePath $DeploymentStatusPath
-
-$asciiArt = @"
-██████╗ ███████╗██████╗ ██╗      ██████╗ ██╗   ██╗███╗   ███╗███████╗███╗   ██╗████████╗    ███████╗████████╗ █████╗ ████████╗██╗   ██╗███████╗
-██╔══██╗██╔════╝██╔══██╗██║     ██╔═══██╗╚██╗ ██╔╝████╗ ████║██╔════╝████╗  ██║╚══██╔══╝    ██╔════╝╚══██╔══╝██╔══██╗╚══██╔══╝██║   ██║██╔════╝
-██║  ██║█████╗  ██████╔╝██║     ██║   ██║ ╚████╔╝ ██╔████╔██║█████╗  ██╔██╗ ██║   ██║       ███████╗   ██║   ███████║   ██║   ██║   ██║███████╗
-██║  ██║██╔══╝  ██╔═══╝ ██║     ██║   ██║  ╚██╔╝  ██║╚██╔╝██║██╔══╝  ██║╚██╗██║   ██║       ╚════██║   ██║   ██╔══██║   ██║   ██║   ██║╚════██║
-██████╔╝███████╗██║     ███████╗╚██████╔╝   ██║   ██║ ╚═╝ ██║███████╗██║ ╚████║   ██║       ███████║   ██║   ██║  ██║   ██║   ╚██████╔╝███████║
-╚═════╝ ╚══════╝╚═╝     ╚══════╝ ╚═════╝    ╚═╝   ╚═╝     ╚═╝╚══════╝╚═╝  ╚═══╝   ╚═╝       ╚══════╝   ╚═╝   ╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚══════╝
-"@
-
-Write-Output $asciiArt | Out-File -FilePath $DeploymentStatusPath -Append
+Write-Output "Deployment Status" | Out-File -FilePath $DeploymentStatusPath
 
 Write-Output "`nTests succeeded: $tests_passed" | Out-File -FilePath $DeploymentStatusPath -Append
 Write-Output "Tests failed: $tests_failed`n" | Out-File -FilePath $DeploymentStatusPath -Append


### PR DESCRIPTION
This pull request includes several enhancements to the PowerShell scripts used in the Azure Jumpstart project. The most important changes include creating a desktop shortcut for the Logs folder, configuring Windows Terminal as the default terminal application, and exporting deployment test results to a log file and resource group tags.

### Enhancements to PowerShell scripts:

* [`azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1`](diffhunk://#diff-d6de137edc1bf7faf44c2484820ccc08202bdd00a18261989c92ffebcf4c3e2cR291-R310): Added code to create a desktop shortcut for the Logs folder and configure Windows Terminal as the default terminal application.

* [`azure_jumpstart_ag/artifacts/PowerShell/tests/Invoke-Test.ps1`](diffhunk://#diff-9f57c5b0d749e3b89cc26ebb2fc194e129230604fbb35a41b6c2819bb4a0b955R22-R67): Enhanced the script to export deployment test results to a log file (`DeploymentStatus.log`) and added ASCII art for better readability.

### Minor adjustments:

* [`azure_jumpstart_ag/artifacts/PowerShell/tests/Invoke-Test.ps1`](diffhunk://#diff-9f57c5b0d749e3b89cc26ebb2fc194e129230604fbb35a41b6c2819bb4a0b955L5): Removed an unnecessary blank line for better code readability.