### PR TITLE
Remove pindown for WinGet modules

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/WinGet.ps1
+++ b/azure_jumpstart_arcbox/artifacts/WinGet.ps1
@@ -17,7 +17,9 @@ Install-PSResource -Name HyperVDsc -Scope AllUsers -Quiet -AcceptLicense -TrustR
 Install-PSResource -Name NetworkingDsc -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
 
 # Install WinGet CLI
-$null = Repair-WinGetPackageManager -AllUsers
+$null = Repair-WinGetPackageManager -AllUsers -Force -Latest
+
+Get-WinGetVersion
 
 Write-Header 'Installing WinGet packages and DSC configurations'
 $winget = Join-Path -Path $env:LOCALAPPDATA -ChildPath Microsoft\WindowsApps\winget.exe

--- a/azure_jumpstart_arcbox/artifacts/WinGet.ps1
+++ b/azure_jumpstart_arcbox/artifacts/WinGet.ps1
@@ -8,8 +8,8 @@ $logFilePath = Join-Path -Path $Env:ArcBoxLogsDir -ChildPath ('WinGet-provisioni
 Start-Transcript -Path $logFilePath -Force -ErrorAction SilentlyContinue
 
 # Install WinGet PowerShell modules
-Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.8.1911
-Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Prerelease -Version 1.8.1911-alpha
+Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
 
 # Install DSC resources required for ArcBox
 Install-PSResource -Name DSCR_Font -Scope AllUsers -Quiet -AcceptLicense -TrustRepository

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/WinGet.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/WinGet.ps1
@@ -7,8 +7,8 @@ $logFilePath = Join-Path -Path $Env:HCIBoxLogsDir -ChildPath ('WinGet-provisioni
 Start-Transcript -Path $logFilePath -Force -ErrorAction SilentlyContinue
 
 # Install WinGet PowerShell modules
-Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.8.1911
-Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Prerelease -Version 1.8.1911-alpha
+Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
 
 # Install DSC resources required for ArcBox
 Install-PSResource -Name DSCR_Font -Scope AllUsers -Quiet -AcceptLicense -TrustRepository

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/WinGet.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/WinGet.ps1
@@ -16,7 +16,9 @@ Install-PSResource -Name HyperVDsc -Scope AllUsers -Quiet -AcceptLicense -TrustR
 Install-PSResource -Name NetworkingDsc -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
 
 # Install WinGet CLI
-$null = Repair-WinGetPackageManager -AllUsers
+$null = Repair-WinGetPackageManager -AllUsers -Force -Latest
+
+Get-WinGetVersion
 
 Write-Output 'Installing WinGet packages and DSC configurations'
 $winget = Join-Path -Path $env:LOCALAPPDATA -ChildPath Microsoft\WindowsApps\winget.exe


### PR DESCRIPTION
This pull request includes updates to the `WinGet.ps1` scripts for both the ArcBox and HCIBox setups. The main changes involve the installation of WinGet PowerShell modules, where specific version constraints have been removed.

Changes to `WinGet.ps1` scripts:

* Removed the version constraints for the `Microsoft.WinGet.Client` and `Microsoft.WinGet.DSC` modules in `azure_jumpstart_arcbox/artifacts/WinGet.ps1`.
* Removed the version constraints for the `Microsoft.WinGet.Client` and `Microsoft.WinGet.DSC` modules in `azure_jumpstart_hcibox/artifacts/PowerShell/WinGet.ps1`.

Fixes #2793 