### PR TITLE
Agora 2.0 - updated login method for tests

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/tests/common.tests.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/tests/common.tests.ps1
@@ -1,9 +1,7 @@
 BeforeDiscovery {
 
-    # Login to Azure PowerShell with service principal provided by user
-    $spnpassword = ConvertTo-SecureString $env:spnClientSecret -AsPlainText -Force
-    $spncredential = New-Object System.Management.Automation.PSCredential ($env:spnClientId, $spnpassword)
-    Connect-AzAccount -ServicePrincipal -Credential $spncredential -Tenant $env:spnTenantId -Subscription $env:subscriptionId
+    # Login to Azure PowerShell with Managed Identity
+    Connect-AzAccount -Identity -Tenant $env:spnTenantId -Subscription $env:subscriptionId
 
 }
 Describe "ArcBox resource group" {

--- a/azure_jumpstart_ag/artifacts/PowerShell/tests/common.tests.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/tests/common.tests.ps1
@@ -1,7 +1,7 @@
 BeforeDiscovery {
 
     # Login to Azure PowerShell with Managed Identity
-    Connect-AzAccount -Identity -Tenant $env:spnTenantId -Subscription $env:subscriptionId
+    Connect-AzAccount -Identity -Subscription $env:subscriptionId
 
 }
 Describe "ArcBox resource group" {

--- a/azure_jumpstart_ag/artifacts/PowerShell/tests/k8s.tests.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/tests/k8s.tests.ps1
@@ -1,7 +1,7 @@
 BeforeDiscovery {
 
     # Login to Azure PowerShell with Managed Identity
-    Connect-AzAccount -Identity -Tenant $env:spnTenantId -Subscription $env:subscriptionId
+    Connect-AzAccount -Identity -Subscription $env:subscriptionId
 
     # Import the configuration data
     $AgConfig = Import-PowerShellDataFile -Path $Env:AgConfigPath

--- a/azure_jumpstart_ag/artifacts/PowerShell/tests/k8s.tests.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/tests/k8s.tests.ps1
@@ -1,9 +1,7 @@
 BeforeDiscovery {
 
-    # Login to Azure PowerShell with service principal provided by user
-    $spnpassword = ConvertTo-SecureString $env:spnClientSecret -AsPlainText -Force
-    $spncredential = New-Object System.Management.Automation.PSCredential ($env:spnClientId, $spnpassword)
-    Connect-AzAccount -ServicePrincipal -Credential $spncredential -Tenant $env:spnTenantId -Subscription $env:subscriptionId
+    # Login to Azure PowerShell with Managed Identity
+    Connect-AzAccount -Identity -Tenant $env:spnTenantId -Subscription $env:subscriptionId
 
     # Import the configuration data
     $AgConfig = Import-PowerShellDataFile -Path $Env:AgConfigPath
@@ -47,7 +45,7 @@ Describe "<cluster>" -ForEach $ArcClusterNames {
                 $containersInCrashLoop = $pod.status.containerStatuses | Where-Object {
                     $_.state.waiting.reason -eq "CrashLoopBackOff"
                 }
-                
+
                 # Ensure there are no containers in CrashLoopBackOff for this pod
                 $containersInCrashLoop | Should -BeNullOrEmpty -Because "Pod $($pod.metadata.name) should not have containers in CrashLoopBackOff"
             }
@@ -56,15 +54,15 @@ Describe "<cluster>" -ForEach $ArcClusterNames {
                 $pod.status.phase | Should -BeIn @("Running", "Succeeded") -Because "Pod $($pod.metadata.name) should be Running or Completed"
             }
         }
-    }       
+    }
     It "Azure IoT Operations - aio-operator service should be online with a valid ClusterIP" {
         # Find the aio-operator service in the list
         $aioOperatorService = $aioServices.items | Where-Object { $_.metadata.name -eq "aio-operator" }
-    
+
         # Verify that the aio-operator service exists
         $aioOperatorService | Should -Not -BeNullOrEmpty -Because "The aio-operator service should exist in the azure-iot-operations namespace"
-    
+
         # Verify that the aio-operator service has a ClusterIP assigned
-        $aioOperatorService.spec.clusterIP | Should -Not -BeNullOrEmpty -Because "The aio-operator service should have a valid ClusterIP assigned"    
+        $aioOperatorService.spec.clusterIP | Should -Not -BeNullOrEmpty -Because "The aio-operator service should have a valid ClusterIP assigned"
     }
 }


### PR DESCRIPTION
This pull request updates the authentication method in the PowerShell test scripts to use Managed Identity instead of service principal credentials.

Authentication method update:

* [`azure_jumpstart_ag/artifacts/PowerShell/tests/common.tests.ps1`](diffhunk://#diff-faaee08bde9c99ce3e3f110a59372cf50f1f6272bcfd95a629dcd7ca682fec6eL3-R4): Changed the login method to Azure PowerShell from service principal to Managed Identity.
* [`azure_jumpstart_ag/artifacts/PowerShell/tests/k8s.tests.ps1`](diffhunk://#diff-415cf7ecd27801ec0a749b0236937873315db330f5055eb1f1460ad18d2a63c7L3-R4): Changed the login method to Azure PowerShell from service principal to Managed Identity.