### PR TITLE
Update azuredeploy.json to remove bad fields

### DIFF
--- a/azure_arc_k8s_jumpstart/aks/arm_template/azuredeploy.json
+++ b/azure_arc_k8s_jumpstart/aks/arm_template/azuredeploy.json
@@ -121,7 +121,6 @@
                         "count": "[parameters('agentCount')]",
                         "vmSize": "[parameters('agentVMSize')]",
                         "osType": "[parameters('osType')]",
-                        "storageProfile": "ManagedDisks",
                         "mode": "System"
                     }
                 ],


### PR DESCRIPTION
AKS ARM templates no longer support setting the storage_profile and therefore this ARM template fails when used. Removed field to enable deployment again.