### PR TITLE
deleted unsupported regions

### DIFF
--- a/azure_jumpstart_hcibox/bicep/main.azd.bicep
+++ b/azure_jumpstart_hcibox/bicep/main.azd.bicep
@@ -41,7 +41,7 @@ param githubBranch string = 'main'
 param deployBastion bool = false
 
 @description('Location to deploy resources')
-@allowed(['eastus', 'eastus2', 'westus2', 'westeurope', 'australiaeast'])
+@allowed(['eastus', 'westeurope', 'australiaeast'])
 param location string
 
 @description('Override default RDP port using this parameter. Default is 3389.')


### PR DESCRIPTION
deleted westus2 and eastus2 as these regions don't support the creation of Azure Stack HCI cluster