### PR TITLE
Addressing issue# 2875, added access policies for the keyvault

### DIFF
--- a/azure_jumpstart_ag/contoso_motors/bicep/data/keyVault.bicep
+++ b/azure_jumpstart_ag/contoso_motors/bicep/data/keyVault.bicep
@@ -24,6 +24,9 @@ param resourceTags object = {
   Project: 'Jumpstart_azure_aio'
 }
 
+@description('Azure service principal object id')
+param spnObjectId string
+
 resource akv 'Microsoft.KeyVault/vaults@2023-02-01' = {
   name: akvNameSite1
   location: location
@@ -33,7 +36,15 @@ resource akv 'Microsoft.KeyVault/vaults@2023-02-01' = {
       name: akvSku
       family: 'A'
     }
-    accessPolicies: []
+    accessPolicies: [
+      {
+      tenantId: tenantId
+      objectId: spnObjectId
+      permissions: {
+        secrets: ['get', 'list']
+      }
+    }
+  ]
     enableSoftDelete: false
     tenantId: tenantId
   }

--- a/azure_jumpstart_ag/contoso_motors/bicep/main.bicep
+++ b/azure_jumpstart_ag/contoso_motors/bicep/main.bicep
@@ -187,6 +187,7 @@ module keyVault 'data/keyVault.bicep' = {
     akvNameSite1: akvNameSite1
     akvNameSite2: akvNameSite2
     location: location
+    spnObjectId: spnObjectId
   }
 }
 


### PR DESCRIPTION
Addressing issue# [2875](https://github.com/microsoft/azure_arc/issues/2875), added access policies for the keyvault to ensure user principal is assigned the proper get and list permission.
Fixes the following issue during the installation:
![image](https://github.com/user-attachments/assets/3af5524f-e275-4826-aa4d-cb3cd32fbc9c)
