### PR TITLE
ArcBox - fix for issue 2886

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -501,12 +501,12 @@ $payLoad = @"
         # Avoid timing issue with copying the authorized_keys file to the Linux VMs
         Start-Sleep -Seconds 5
 
-        Copy-Item -Path "$Env:USERPROFILE\.ssh\id_rsa.pub" -Destination "$Env:TEMP\authorized_keys"
+        Copy-Item -Path "$Env:USERPROFILE\.ssh\id_rsa.pub" -Destination "$($Env:ArcBoxDir)\authorized_keys"
 
         # Automatically accept unseen keys but will refuse connections for changed or invalid hostkeys.
         Add-Content -Path "$Env:USERPROFILE\.ssh\config" -Value "StrictHostKeyChecking=accept-new"
 
-        Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$Env:TEMP\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
+        Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
 
         if ($namingPrefix -ne "ArcBox") {
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -503,6 +503,9 @@ $payLoad = @"
         # Automatically accept unseen keys but will refuse connections for changed or invalid hostkeys.
         Add-Content -Path "$Env:USERPROFILE\.ssh\config" -Value "StrictHostKeyChecking=accept-new"
 
+        # Avoid timing issue with copying the authorized_keys file to the Linux VMs
+        Start-Sleep -Seconds 5
+
         Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$Env:TEMP\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
 
         if ($namingPrefix -ne "ArcBox") {

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -498,13 +498,13 @@ $payLoad = @"
         $null = New-Item -Path ~ -Name .ssh -ItemType Directory
         ssh-keygen -t rsa -N '' -f $Env:USERPROFILE\.ssh\id_rsa
 
+        # Avoid timing issue with copying the authorized_keys file to the Linux VMs
+        Start-Sleep -Seconds 5
+
         Copy-Item -Path "$Env:USERPROFILE\.ssh\id_rsa.pub" -Destination "$Env:TEMP\authorized_keys"
 
         # Automatically accept unseen keys but will refuse connections for changed or invalid hostkeys.
         Add-Content -Path "$Env:USERPROFILE\.ssh\config" -Value "StrictHostKeyChecking=accept-new"
-
-        # Avoid timing issue with copying the authorized_keys file to the Linux VMs
-        Start-Sleep -Seconds 5
 
         Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$Env:TEMP\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -510,10 +510,8 @@ $payLoad = @"
         # Automatically accept unseen keys but will refuse connections for changed or invalid hostkeys.
         Add-Content -Path "$Env:USERPROFILE\.ssh\config" -Value "StrictHostKeyChecking=accept-new"
 
-        # Waiting for Linux VMs to come online
-        Start-Sleep -Seconds 10
-
-        Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
+        Copy-VMFile -Name $Ubuntu01vmName -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
+        Copy-VMFile -Name $Ubuntu02vmName -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
 
         if ($namingPrefix -ne "ArcBox") {
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -512,19 +512,19 @@ $payLoad = @"
 
                 Invoke-Command -HostName $Ubuntu01VmIp -KeyFilePath "$Env:USERPROFILE\.ssh\id_rsa" -UserName $nestedLinuxUsername -ScriptBlock {
 
-                    Invoke-Expression "sudo hostnamectl set-hostname $using:ubuntu01vmName;sudo systemctl reboot"
+                    Invoke-Expression "sudo hostnamectl set-hostname $using:ubuntu01vmName"
 
                 }
 
-                Restart-VM -Name $ubuntu01vmName
+                Restart-VM -Name $ubuntu01vmName -Force
 
                 Invoke-Command -HostName $Ubuntu02VmIp -KeyFilePath "$Env:USERPROFILE\.ssh\id_rsa" -UserName $nestedLinuxUsername -ScriptBlock {
 
-                    Invoke-Expression "sudo hostnamectl set-hostname $using:ubuntu02vmName;sudo systemctl reboot"
+                    Invoke-Expression "sudo hostnamectl set-hostname $using:ubuntu02vmName"
 
                 }
 
-                Restart-VM -Name $ubuntu02vmName
+                Restart-VM -Name $ubuntu02vmName -Force
 
             }
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -407,16 +407,16 @@ $payLoad = @"
         Write-Header "Fetching Nested VMs"
 
         $Win2k19vmName = "$namingPrefix-Win2K19"
-        $win2k19vmvhdPath = "${Env:ArcBoxVMDir}\ArcBox-Win2K19.vhdx"
+        $win2k19vmvhdPath = "${Env:ArcBoxVMDir}\$namingPrefix-Win2K19.vhdx"
 
         $Win2k22vmName = "$namingPrefix-Win2K22"
-        $Win2k22vmvhdPath = "${Env:ArcBoxVMDir}\ArcBox-Win2K22.vhdx"
+        $Win2k22vmvhdPath = "${Env:ArcBoxVMDir}\$namingPrefix-Win2K22.vhdx"
 
         $Ubuntu01vmName = "$namingPrefix-Ubuntu-01"
-        $Ubuntu01vmvhdPath = "${Env:ArcBoxVMDir}\ArcBox-Ubuntu-01.vhdx"
+        $Ubuntu01vmvhdPath = "${Env:ArcBoxVMDir}\$namingPrefix-Ubuntu-01.vhdx"
 
         $Ubuntu02vmName = "$namingPrefix-Ubuntu-02"
-        $Ubuntu02vmvhdPath = "${Env:ArcBoxVMDir}\ArcBox-Ubuntu-02.vhdx"
+        $Ubuntu02vmvhdPath = "${Env:ArcBoxVMDir}\$namingPrefix-Ubuntu-02.vhdx"
 
         # Verify if VHD files already downloaded especially when re-running this script
         if (!((Test-Path $win2k19vmvhdPath) -and (Test-Path $Win2k22vmvhdPath) -and (Test-Path $Ubuntu01vmvhdPath) -and (Test-Path $Ubuntu02vmvhdPath))) {

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -510,6 +510,9 @@ $payLoad = @"
         # Automatically accept unseen keys but will refuse connections for changed or invalid hostkeys.
         Add-Content -Path "$Env:USERPROFILE\.ssh\config" -Value "StrictHostKeyChecking=accept-new"
 
+        # Waiting for Linux VMs to come online
+        Start-Sleep -Seconds 10
+
         Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
 
         if ($namingPrefix -ne "ArcBox") {

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -477,14 +477,14 @@ $payLoad = @"
 
             # Renaming the nested VMs
             Write-Header "Renaming the nested Windows VMs"
-            Invoke-Command -VMName $Win2k19vmName -ScriptBlock { Rename-Computer -newName $using:Win2k19vmName -Restart } -Credential $winCreds
-            Invoke-Command -VMName $Win2k22vmName -ScriptBlock { Rename-Computer -newName $using:Win2k22vmName -Restart } -Credential $winCreds
+            Invoke-Command -VMName $Win2k19vmName -ScriptBlock { Rename-Computer -NewName $using:Win2k19vmName } -Credential $winCreds
+            Invoke-Command -VMName $Win2k22vmName -ScriptBlock { Rename-Computer -NewName $using:Win2k22vmName } -Credential $winCreds
 
-            Get-VM *Win* | Wait-VM -For IPAddress
+            Write-Host "Waiting for the nested Windows VMs to come back online..."
 
-            Write-Host "Waiting for the nested Windows VMs to come back online...waiting for 10 seconds"
+            Get-VM *Win* | Restart-VM -Force
+            Get-VM *Win* | Wait-VM -For Heartbeat
 
-            Start-Sleep -Seconds 10
 
         }
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -498,8 +498,12 @@ $payLoad = @"
         $null = New-Item -Path ~ -Name .ssh -ItemType Directory
         ssh-keygen -t rsa -N '' -f $Env:USERPROFILE\.ssh\id_rsa
 
-        # Avoid timing issue with copying the authorized_keys file to the Linux VMs
-        Start-Sleep -Seconds 5
+        # Avoid timing issue with copying the authorized_keys file
+        do {
+            Write-Output "Waiting for SSH public key to become available..."
+            $fileSize = (Get-Item "$Env:USERPROFILE\.ssh\id_rsa.pub").Length
+            Start-Sleep -Seconds 1
+        } while ($fileSize -eq 0)
 
         Copy-Item -Path "$Env:USERPROFILE\.ssh\id_rsa.pub" -Destination "$($Env:ArcBoxDir)\authorized_keys"
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -510,8 +510,9 @@ $payLoad = @"
         # Automatically accept unseen keys but will refuse connections for changed or invalid hostkeys.
         Add-Content -Path "$Env:USERPROFILE\.ssh\config" -Value "StrictHostKeyChecking=accept-new"
 
-        Copy-VMFile -Name $Ubuntu01vmName -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
-        Copy-VMFile -Name $Ubuntu02vmName -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
+        # Running twice due to a race condition where the target file is sometimes empty
+        Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
+        Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
 
         if ($namingPrefix -ne "ArcBox") {
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -516,6 +516,9 @@ $payLoad = @"
         Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
         Get-VM *Ubuntu* | Copy-VMFile -SourcePath "$($Env:ArcBoxDir)\authorized_keys" -DestinationPath "/home/$nestedLinuxUsername/.ssh/" -FileSource Host -Force -CreateFullPath
 
+        # Remove the authorized_keys file from the local machine
+        Remove-Item -Path "$($Env:ArcBoxDir)\authorized_keys"
+
         if ($namingPrefix -ne "ArcBox") {
 
                 # Renaming the nested linux VMs

--- a/azure_jumpstart_arcbox/artifacts/dsc/virtual_machines_itpro.dsc.yml
+++ b/azure_jumpstart_arcbox/artifacts/dsc/virtual_machines_itpro.dsc.yml
@@ -9,7 +9,7 @@ properties:
       settings:
         Name: namingPrefixStage-Win2K19
         SwitchName: 'InternalNATSwitch'
-        VhdPath: F:\Virtual Machines\ArcBox-Win2K19.vhdx
+        VhdPath: F:\Virtual Machines\namingPrefixStage-Win2K19.vhdx
         ProcessorCount: 2
         StartupMemory: '4GB'
         RestartIfNeeded: true
@@ -25,7 +25,7 @@ properties:
       settings:
         Name: namingPrefixStage-Win2K22
         SwitchName: 'InternalNATSwitch'
-        VhdPath: F:\Virtual Machines\ArcBox-Win2K22.vhdx
+        VhdPath: F:\Virtual Machines\namingPrefixStage-Win2K22.vhdx
         ProcessorCount: 2
         StartupMemory: '4GB'
         RestartIfNeeded: true
@@ -41,7 +41,7 @@ properties:
       settings:
         Name: namingPrefixStage-Ubuntu-01
         SwitchName: 'InternalNATSwitch'
-        VhdPath: F:\Virtual Machines\ArcBox-Ubuntu-01.vhdx
+        VhdPath: F:\Virtual Machines\namingPrefixStage-Ubuntu-01.vhdx
         ProcessorCount: 2
         StartupMemory: '4GB'
         RestartIfNeeded: true
@@ -57,7 +57,7 @@ properties:
       settings:
         Name: namingPrefixStage-Ubuntu-02
         SwitchName: 'InternalNATSwitch'
-        VhdPath: F:\Virtual Machines\ArcBox-Ubuntu-02.vhdx
+        VhdPath: F:\Virtual Machines\namingPrefixStage-Ubuntu-02.vhdx
         ProcessorCount: 2
         StartupMemory: '4GB'
         RestartIfNeeded: true

--- a/azure_jumpstart_arcbox/artifacts/dsc/virtual_machines_sql.dsc.yml
+++ b/azure_jumpstart_arcbox/artifacts/dsc/virtual_machines_sql.dsc.yml
@@ -8,7 +8,7 @@ properties:
       settings:
         Name: namingPrefixStage-SQL
         SwitchName: 'InternalNATSwitch'
-        VhdPath: F:\Virtual Machines\ArcBox-SQL.vhdx
+        VhdPath: F:\Virtual Machines\namingPrefixStage-SQL.vhdx
         ProcessorCount: 2
         StartupMemory: '6GB'
         RestartIfNeeded: true


### PR DESCRIPTION
This pull request includes several updates to the `azure_jumpstart_arcbox` project, primarily focused on improving the handling of VM naming conventions and VHD file paths. The most important changes include updating file paths to include a naming prefix, adding logic to rename VHD files based on the naming prefix, and modifying VM restart commands.

### VM Naming and File Path Updates:
* Updated VHD file paths to include the `$namingPrefix` variable in `ArcServersLogonScript.ps1` to ensure unique paths for different VM instances.
* Added logic to rename VHD files based on the `$namingPrefix` variable in `ArcServersLogonScript.ps1`, ensuring that files are properly named and managed.

### VM Restart Command Updates:
* Modified VM restart commands to use the `-Force` parameter in `ArcServersLogonScript.ps1` to ensure VMs are restarted without prompting for confirmation.

### DSC Configuration Updates:
* Updated VHD file paths in `virtual_machines_itpro.dsc.yml` to include the naming prefix for various VM configurations (`Win2K19`, `Win2K22`, `Ubuntu-01`, `Ubuntu-02`). [[1]](diffhunk://#diff-30a98cb499069b93869d51f2f4bc86960cf776ac24103659cd8e8197b07a5809L12-R12) [[2]](diffhunk://#diff-30a98cb499069b93869d51f2f4bc86960cf776ac24103659cd8e8197b07a5809L28-R28) [[3]](diffhunk://#diff-30a98cb499069b93869d51f2f4bc86960cf776ac24103659cd8e8197b07a5809L44-R44) [[4]](diffhunk://#diff-30a98cb499069b93869d51f2f4bc86960cf776ac24103659cd8e8197b07a5809L60-R60)
* Updated VHD file path in `virtual_machines_sql.dsc.yml` to include the naming prefix for the SQL VM configuration.

- Fixes #2886 