### PR TITLE
Temporarily moved azcopy installation

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-contoso-hypermarket.psd1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-contoso-hypermarket.psd1
@@ -81,7 +81,7 @@
         'Microsoft.Bicep',
         'Kubernetes.kubectl',
         'Microsoft.Edge',
-        'Microsoft.Azure.AZCopy.10',
+        #'Microsoft.Azure.AZCopy.10',
         'Microsoft.VisualStudioCode',
         'Microsoft.AzureDataStudio',
         'Microsoft.VisualStudioCode',

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-contoso-motors.psd1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-contoso-motors.psd1
@@ -77,7 +77,7 @@
         'Microsoft.Bicep',
         'Kubernetes.kubectl',
         'Microsoft.Edge',
-        'Microsoft.Azure.AZCopy.10',
+        #'Microsoft.Azure.AZCopy.10',
         'Microsoft.AzureDataStudio',
         'Microsoft.VisualStudioCode',
         'Microsoft.SQLServerManagementStudio',

--- a/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-contoso-supermarket.psd1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgConfig-contoso-supermarket.psd1
@@ -64,7 +64,7 @@
         'Microsoft.Bicep',
         'Kubernetes.kubectl',
         'Microsoft.Edge',
-        'Microsoft.Azure.AZCopy.10',
+        #'Microsoft.Azure.AZCopy.10',
         'Microsoft.VisualStudioCode',
         'Microsoft.AzureDataStudio',
         'Microsoft.VisualStudioCode',

--- a/azure_jumpstart_ag/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Bootstrap.ps1
@@ -306,6 +306,7 @@ Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/tests/common.tests.p
 Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/tests/k8s.tests.ps1") -OutFile "$AgDirectory\tests\k8s.tests.ps1"
 Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/tests/Invoke-Test.ps1") -OutFile "$AgDirectory\tests\Invoke-Test.ps1"
 Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/tests/ag-bginfo.bgi") -OutFile "$AgDirectory\tests\ag-bginfo.bgi"
+Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/azcopy_install.ps1") -OutFile "$AgPowerShellDir\azcopy_install.ps1"
 
 if($scenario -eq "contoso_supermarket"){
   Invoke-WebRequest ($templateBaseUrl + "artifacts/settings/Bookmarks-contoso-supermarket") -OutFile "$AgToolsDir\Bookmarks"

--- a/azure_jumpstart_ag/artifacts/PowerShell/Winget.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Winget.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = 'SilentlyContinue'
 $AgDir = 'C:\Ag'
 $AgLogsDir = "$AgDir\Logs"
 $AgConfig = Import-PowerShellDataFile -Path $Env:AgConfigPath
+$AgPowerShellDir    = $AgConfig.AgDirectories["AgPowerShellDir"]
 
 $logFilePath = Join-Path -Path $AgLogsDir -ChildPath ('WinGet-provisioning-' + (Get-Date -Format 'yyyyMMddHHmmss') + '.log')
 
@@ -19,6 +20,9 @@ $winget = Join-Path -Path $env:LOCALAPPDATA -ChildPath Microsoft\WindowsApps\win
 
 # Windows Terminal needs to be installed per user, while WinGet Configuration runs as SYSTEM. Hence, this package is installed in the logon script.
 & $winget install Microsoft.WindowsTerminal --version 1.18.3181.0 -s winget --silent --accept-package-agreements
+
+# Temporary workaround for AzCopy installation due to CDN issues
+& $AgPowerShellDir\azcopy_install.ps1
 
 ##############################################################
 # Install Winget packages

--- a/azure_jumpstart_ag/artifacts/PowerShell/azcopy_install.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/azcopy_install.ps1
@@ -1,0 +1,48 @@
+$azCopyUrl = "https://aka.ms/downloadazcopy-v10-windows"
+$downloadPath = "$env:TEMP\azcopy.zip"
+$destinationFolder = "C:\Program Files\AzCopy"
+
+
+# Download the AzCopy zip file
+Write-Host "Downloading AzCopy from $azCopyUrl..."
+Invoke-WebRequest -Uri $azCopyUrl -OutFile $downloadPath -ErrorAction Stop
+Write-Host "Download completed."
+
+# Create the destination folder if it doesn't exist
+if (-not (Test-Path -Path $destinationFolder)) {
+    Write-Host "Creating destination folder: $destinationFolder"
+    New-Item -ItemType Directory -Path $destinationFolder -Force
+}
+
+# Extract the AzCopy zip file
+Write-Host "Extracting AzCopy to $destinationFolder..."
+Expand-Archive -Path $downloadPath -DestinationPath $destinationFolder -Force
+Write-Host "Extraction completed."
+
+# Move the contents of the azcopy subfolder one level up
+$subfolder = Get-ChildItem -Path $destinationFolder -Directory | Where-Object { $_.Name -match "azcopy_windows_amd64" }
+if ($subfolder) {
+    Write-Host "Moving contents of $($subfolder.Name) one level up..."
+    Move-Item -Path "$($subfolder.FullName)\*" -Destination $destinationFolder -Force
+    Remove-Item -Path $subfolder.FullName -Recurse -Force
+    Write-Host "Contents moved successfully."
+} else {
+    Write-Host "No subfolder matching 'azcopy_windows_amd64' found. Skipping move."
+}
+
+# Update the Path environment variable
+Write-Host "Updating Path environment variable..."
+$envPath = [Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine)
+if (-not $envPath.Contains($destinationFolder)) {
+    [Environment]::SetEnvironmentVariable("Path", "$envPath;$destinationFolder", [System.EnvironmentVariableTarget]::Machine)
+    Write-Host "Path variable updated. Please restart PowerShell to reflect changes."
+} else {
+    Write-Host "Path already contains $destinationFolder. No changes made."
+}
+
+# Clean up
+Write-Host "Cleaning up temporary files..."
+Remove-Item -Path $downloadPath -Force
+Write-Host "Temporary files cleaned up."
+
+Write-Host "AzCopy installation and setup completed."

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -220,6 +220,7 @@ Invoke-WebRequest ($templateBaseUrl + "artifacts/tests/arcbox-bginfo.bgi") -OutF
 Invoke-WebRequest ($templateBaseUrl + "artifacts/tests/common.tests.ps1") -OutFile $Env:ArcBoxTestsDir\common.tests.ps1
 Invoke-WebRequest ($templateBaseUrl + "artifacts/tests/Invoke-Test.ps1") -OutFile $Env:ArcBoxTestsDir\Invoke-Test.ps1
 Invoke-WebRequest ($templateBaseUrl + "artifacts/WinGet.ps1") -OutFile $Env:ArcBoxDir\WinGet.ps1
+Invoke-WebRequest ($templateBaseUrl + "artifacts/azcopy_install.ps1") -OutFile $Env:ArcBoxDir\azcopy_install.ps1
 
 # Workbook template
 if ($flavor -eq "ITPro") {

--- a/azure_jumpstart_arcbox/artifacts/WinGet.ps1
+++ b/azure_jumpstart_arcbox/artifacts/WinGet.ps1
@@ -36,6 +36,9 @@ switch ($env:flavor) {
     'ITPro' { & $winget configure --file C:\ArcBox\DSC\itpro.dsc.yml --accept-configuration-agreements --disable-interactivity }
 }
 
+# Temporary workaround for AzCopy installation due to CDN issues
+& $Env:ArcBoxDir\azcopy_install.ps1
+
 # Start remaining logon scripts
 Get-ScheduledTask *LogonScript* | Start-ScheduledTask
 

--- a/azure_jumpstart_arcbox/artifacts/azcopy_install.ps1
+++ b/azure_jumpstart_arcbox/artifacts/azcopy_install.ps1
@@ -1,0 +1,48 @@
+$azCopyUrl = "https://aka.ms/downloadazcopy-v10-windows"
+$downloadPath = "$env:TEMP\azcopy.zip"
+$destinationFolder = "C:\Program Files\AzCopy"
+
+
+# Download the AzCopy zip file
+Write-Host "Downloading AzCopy from $azCopyUrl..."
+Invoke-WebRequest -Uri $azCopyUrl -OutFile $downloadPath -ErrorAction Stop
+Write-Host "Download completed."
+
+# Create the destination folder if it doesn't exist
+if (-not (Test-Path -Path $destinationFolder)) {
+    Write-Host "Creating destination folder: $destinationFolder"
+    New-Item -ItemType Directory -Path $destinationFolder -Force
+}
+
+# Extract the AzCopy zip file
+Write-Host "Extracting AzCopy to $destinationFolder..."
+Expand-Archive -Path $downloadPath -DestinationPath $destinationFolder -Force
+Write-Host "Extraction completed."
+
+# Move the contents of the azcopy subfolder one level up
+$subfolder = Get-ChildItem -Path $destinationFolder -Directory | Where-Object { $_.Name -match "azcopy_windows_amd64" }
+if ($subfolder) {
+    Write-Host "Moving contents of $($subfolder.Name) one level up..."
+    Move-Item -Path "$($subfolder.FullName)\*" -Destination $destinationFolder -Force
+    Remove-Item -Path $subfolder.FullName -Recurse -Force
+    Write-Host "Contents moved successfully."
+} else {
+    Write-Host "No subfolder matching 'azcopy_windows_amd64' found. Skipping move."
+}
+
+# Update the Path environment variable
+Write-Host "Updating Path environment variable..."
+$envPath = [Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine)
+if (-not $envPath.Contains($destinationFolder)) {
+    [Environment]::SetEnvironmentVariable("Path", "$envPath;$destinationFolder", [System.EnvironmentVariableTarget]::Machine)
+    Write-Host "Path variable updated. Please restart PowerShell to reflect changes."
+} else {
+    Write-Host "Path already contains $destinationFolder. No changes made."
+}
+
+# Clean up
+Write-Host "Cleaning up temporary files..."
+Remove-Item -Path $downloadPath -Force
+Write-Host "Temporary files cleaned up."
+
+Write-Host "AzCopy installation and setup completed."

--- a/azure_jumpstart_arcbox/artifacts/dsc/common.dsc.yml
+++ b/azure_jumpstart_arcbox/artifacts/dsc/common.dsc.yml
@@ -44,13 +44,13 @@ properties:
       settings:
         id: Microsoft.Edge
         source: winget
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: azcopy
-      directives:
-        description: Install azcopy
-      settings:
-        id: Microsoft.Azure.AZCopy.10
-        source: winget
+    # - resource: Microsoft.WinGet.DSC/WinGetPackage
+    #   id: azcopy
+    #   directives:
+    #     description: Install azcopy
+    #   settings:
+    #     id: Microsoft.Azure.AZCopy.10
+    #     source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: DotNetSDK8
       directives:

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
@@ -123,6 +123,7 @@ Invoke-WebRequest ($templateBaseUrl + "artifacts/hci.parameters.json") -OutFile 
 Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/dsc/packages.dsc.yml") -OutFile "$($HCIBoxConfig.Paths["DSCDir"])\packages.dsc.yml"
 Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/dsc/hyper-v.dsc.yml") -OutFile "$($HCIBoxConfig.Paths["DSCDir"])\hyper-v.dsc.yml"
 Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/WinGet.ps1") -OutFile "$HCIPath\WinGet.ps1"
+Invoke-WebRequest ($templateBaseUrl + "artifacts/PowerShell/azcopy_install.ps1") -OutFile "$HCIPath\azcopy_install.ps1"
 
 # Replace password and DNS placeholder
 Write-Host "Updating config placeholders with injected values."

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/WinGet.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/WinGet.ps1
@@ -26,6 +26,9 @@ $winget = Join-Path -Path $env:LOCALAPPDATA -ChildPath Microsoft\WindowsApps\win
 # Windows Terminal needs to be installed per user, while WinGet Configuration runs as SYSTEM. Hence, this package is installed in the logon script.
 & $winget install Microsoft.WindowsTerminal --version 1.18.3181.0 -s winget
 
+# Temporary workaround for AzCopy installation due to CDN issues
+& "$($Env:HCIBoxDir)\azcopy_install.ps1"
+
 # Apply WinGet Configuration files
 & $winget configure --file "$($Env:HCIBoxDir)\DSC\packages.dsc.yml" --accept-configuration-agreements --disable-interactivity
 & $winget configure --file "$($Env:HCIBoxDir)\DSC\hyper-v.dsc.yml" --accept-configuration-agreements --disable-interactivity

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/azcopy_install.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/azcopy_install.ps1
@@ -1,0 +1,48 @@
+$azCopyUrl = "https://aka.ms/downloadazcopy-v10-windows"
+$downloadPath = "$env:TEMP\azcopy.zip"
+$destinationFolder = "C:\Program Files\AzCopy"
+
+
+# Download the AzCopy zip file
+Write-Host "Downloading AzCopy from $azCopyUrl..."
+Invoke-WebRequest -Uri $azCopyUrl -OutFile $downloadPath -ErrorAction Stop
+Write-Host "Download completed."
+
+# Create the destination folder if it doesn't exist
+if (-not (Test-Path -Path $destinationFolder)) {
+    Write-Host "Creating destination folder: $destinationFolder"
+    New-Item -ItemType Directory -Path $destinationFolder -Force
+}
+
+# Extract the AzCopy zip file
+Write-Host "Extracting AzCopy to $destinationFolder..."
+Expand-Archive -Path $downloadPath -DestinationPath $destinationFolder -Force
+Write-Host "Extraction completed."
+
+# Move the contents of the azcopy subfolder one level up
+$subfolder = Get-ChildItem -Path $destinationFolder -Directory | Where-Object { $_.Name -match "azcopy_windows_amd64" }
+if ($subfolder) {
+    Write-Host "Moving contents of $($subfolder.Name) one level up..."
+    Move-Item -Path "$($subfolder.FullName)\*" -Destination $destinationFolder -Force
+    Remove-Item -Path $subfolder.FullName -Recurse -Force
+    Write-Host "Contents moved successfully."
+} else {
+    Write-Host "No subfolder matching 'azcopy_windows_amd64' found. Skipping move."
+}
+
+# Update the Path environment variable
+Write-Host "Updating Path environment variable..."
+$envPath = [Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine)
+if (-not $envPath.Contains($destinationFolder)) {
+    [Environment]::SetEnvironmentVariable("Path", "$envPath;$destinationFolder", [System.EnvironmentVariableTarget]::Machine)
+    Write-Host "Path variable updated. Please restart PowerShell to reflect changes."
+} else {
+    Write-Host "Path already contains $destinationFolder. No changes made."
+}
+
+# Clean up
+Write-Host "Cleaning up temporary files..."
+Remove-Item -Path $downloadPath -Force
+Write-Host "Temporary files cleaned up."
+
+Write-Host "AzCopy installation and setup completed."

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/dsc/packages.dsc.yml
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/dsc/packages.dsc.yml
@@ -44,13 +44,13 @@ properties:
       settings:
         id: Microsoft.Edge
         source: winget
-    - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: azcopy
-      directives:
-        description: Install azcopy
-      settings:
-        id: Microsoft.Azure.AZCopy.10
-        source: winget
+    # - resource: Microsoft.WinGet.DSC/WinGetPackage
+    #   id: azcopy
+    #   directives:
+    #     description: Install azcopy
+    #   settings:
+    #     id: Microsoft.Azure.AZCopy.10
+    #     source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: DotNetSDK8
       directives:


### PR DESCRIPTION
This pull request includes several changes aimed at addressing issues with the installation of AzCopy due to CDN problems. The changes primarily involve commenting out the existing AzCopy installation commands and introducing a new script to handle the installation. The most important changes include updates to multiple configuration files and the addition of a new PowerShell script for installing AzCopy.

### Updates to AzCopy Installation:

* Commented out the existing AzCopy installation commands in `AgConfig-contoso-hypermarket.psd1`, `AgConfig-contoso-motors.psd1`, and `AgConfig-contoso-supermarket.psd1` to prevent issues during setup. [[1]](diffhunk://#diff-98a360a6e79e64c99968196b7bc2d13e4109a93630ff2208e6b1704ef8f269aeL84-R84) [[2]](diffhunk://#diff-f3f2d6b52ddfdddfff1019b279930566c887ecefa55e9c6ec5a00ecd28c06347L80-R80) [[3]](diffhunk://#diff-c33b762b079b6b8b538df0982257acfdaf1179d4649aadf1ed719bbfa5499c3fL67-R67)
* Added a new PowerShell script `azcopy_install.ps1` for downloading, extracting, and setting up AzCopy. This script is referenced in the Bootstrap files for various configurations.

### Configuration File Updates:

* Updated `Bootstrap.ps1` files to include the new `azcopy_install.ps1` script for different configurations, such as `azure_jumpstart_ag`, `azure_jumpstart_arcbox`, and `azure_jumpstart_hcibox`. [[1]](diffhunk://#diff-6e839dc3c4f9281f10ab23a74fc05babffdbb62beac1df0d3eea2f7f02518268R309) [[2]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R223) [[3]](diffhunk://#diff-0bedbbf2c2a412589fe06320754e5471c9cd49f1182e7d2734de4ed206c23b19R126)
* Added the execution of `azcopy_install.ps1` as a temporary workaround in `Winget.ps1` files for different configurations. [[1]](diffhunk://#diff-189e9239ef746e1c31d9c5e55dbde18cc30392c5ff265120f1f3b857baf0cb05R24-R26) [[2]](diffhunk://#diff-052ac08b482fd0b1856485ecfb9c7e5d4a40e265a0f80bced64db99e149edafdR39-R41) [[3]](diffhunk://#diff-de9acfbf8c1ae0a77ff6641aecb66538bf5b4f4b127c837096c2c82a22b96256R29-R31)

### Commented Out AzCopy Resource in DSC Files:

* Commented out the AzCopy resource in the DSC configuration files `common.dsc.yml` and `packages.dsc.yml` to prevent conflicts with the new installation method. [[1]](diffhunk://#diff-1c30156061aac3ca7ce79af817977cb817dbd5a78efe1a3d9e62e548b0324b62L47-R53) [[2]](diffhunk://#diff-555983a0d351f79a5b2467c264a6530c5c9aaae333e4b7efd3e0886cf2aa5bd2L47-R53)

Fixes https://github.com/microsoft/azure_arc/issues/2888