### PR TITLE
Azure VM Scenario - clarify expected value for SPN

### DIFF
--- a/azure_arc_servers_jumpstart/azure/linux/arm_template/azuredeploy.parameters.json
+++ b/azure_arc_servers_jumpstart/azure/linux/arm_template/azuredeploy.parameters.json
@@ -27,7 +27,7 @@
       "value": "<Azure Bastion Host name>"
     },
     "servicePrincipalClient": {
-      "value": "<Your Azure service principal name>"
+      "value": "<Your Azure service principal application ID>"
     },
     "servicePrincipalClientSecret": {
       "value": "<Your Azure service principal password>"


### PR DESCRIPTION
This PR changes the description of the **servicePrincipalClient** to clarify the expected value.  Service principal name can be mistaken to be the display name of the service principal, whereas the application ID is what's needed to successfully onboard the machine.

This will prevent users from seeing the following error message when trying to onboard a machine:

"AADSTS700016: Application with identifier '<name of SPN>' was not found in the directory '<tenant name>'. This can happen if the application has not been installed by the administrator of the tenant or consented to
 by any user in the tenant. You may have sent your authentication request to the wrong tenant."