### PR TITLE
Disable SharedKeyAccess on the storage account

### DIFF
--- a/azure_jumpstart_hcibox/bicep/mgmt/storageAccount.bicep
+++ b/azure_jumpstart_hcibox/bicep/mgmt/storageAccount.bicep
@@ -21,6 +21,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
   kind: 'StorageV2'
   properties: {
     supportsHttpsTrafficOnly: true
+    allowSharedKeyAccess: false
   }
 }
 


### PR DESCRIPTION
Disable SharedKeyAccess on the storage account since not allowed by best practice