### PR TITLE
Update hci.json to set allowSharedKeyAccess to FALSE

### DIFF
--- a/azure_jumpstart_hcibox/artifacts/hci.json
+++ b/azure_jumpstart_hcibox/artifacts/hci.json
@@ -556,8 +556,9 @@
         },
         "kind": "StorageV2",
         "properties": {
+          "allowSharedKeyAccess": false,
           "supportsHttpsTrafficOnly": true,
-           "minimumTlsVersion": "TLS1_2"
+          "minimumTlsVersion": "TLS1_2"
         }
       },
       {
@@ -661,6 +662,7 @@
         "kind": "StorageV2",
         "properties": {
           "publicNetworkAccess": "Disabled",
+          "allowSharedKeyAccess": false,
           "supportsHttpsTrafficOnly": true,
            "minimumTlsVersion": "TLS1_2",
            "networkAcls": {


### PR DESCRIPTION
Modified the template to set allowSharedKeyAccess to FALSE on Storage Accounts as per best practices