### PR TITLE
ArcBox - Security enhancements

### DIFF
--- a/azure_jumpstart_arcbox/ARM/azuredeploy.json
+++ b/azure_jumpstart_arcbox/ARM/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.32.4.45862",
-      "templateHash": "16300004813439680800"
+      "templateHash": "11114503493889055176"
     }
   },
   "parameters": {
@@ -31,6 +31,7 @@
     },
     "windowsAdminPassword": {
       "type": "securestring",
+      "defaultValue": "[newGuid()]",
       "minLength": 12,
       "maxLength": 123,
       "metadata": {
@@ -53,6 +54,7 @@
     },
     "logAnalyticsWorkspaceName": {
       "type": "string",
+      "defaultValue": "ArcBox-la",
       "metadata": {
         "description": "Name for your log analytics workspace"
       }
@@ -207,6 +209,10 @@
       "metadata": {
         "description": "The availability zone for the Virtual Machine, public IP, and data disk for the ArcBox client VM"
       }
+    },
+    "registryPassword": {
+      "type": "securestring",
+      "defaultValue": "[newGuid()]"
     }
   },
   "variables": {
@@ -1444,9 +1450,6 @@
           "windowsAdminPassword": {
             "value": "[parameters('windowsAdminPassword')]"
           },
-          "azdataPassword": {
-            "value": "[parameters('windowsAdminPassword')]"
-          },
           "tenantId": {
             "value": "[parameters('tenantId')]"
           },
@@ -1534,7 +1537,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.32.4.45862",
-              "templateHash": "1720726630847060036"
+              "templateHash": "16893232953418081903"
             }
           },
           "parameters": {
@@ -1615,9 +1618,6 @@
               "type": "string",
               "defaultValue": "arcdemo"
             },
-            "azdataPassword": {
-              "type": "securestring"
-            },
             "acceptEula": {
               "type": "string",
               "defaultValue": "yes"
@@ -1625,10 +1625,6 @@
             "registryUsername": {
               "type": "string",
               "defaultValue": "registryUser"
-            },
-            "registryPassword": {
-              "type": "securestring",
-              "defaultValue": "[newGuid()]"
             },
             "arcDcName": {
               "type": "string",
@@ -1984,7 +1980,7 @@
                   "fileUris": [
                     "[uri(parameters('templateBaseUrl'), 'artifacts/Bootstrap.ps1')]"
                   ],
-                  "commandToExecute": "[format('powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername {0} -adminPassword {1} -tenantId {2} -spnAuthority {3} -subscriptionId {4} -resourceGroup {5} -azdataUsername {6} -azdataPassword {7} -acceptEula {8} -registryUsername {9} -registryPassword {10} -arcDcName {11} -azureLocation {12} -mssqlmiName {13} -POSTGRES_NAME {14} -POSTGRES_WORKER_NODE_COUNT {15} -POSTGRES_DATASIZE {16} -POSTGRES_SERVICE_TYPE {17} -stagingStorageAccountName {18} -workspaceName {19} -templateBaseUrl {20} -flavor {21} -k3sArcDataClusterName {22} -k3sArcClusterName {23} -aksArcClusterName {24} -aksdrArcClusterName {25} -githubUser {26} -githubBranch {27} -vmAutologon {28} -rdpPort {29} -addsDomainName {30} -customLocationRPOID {31} -resourceTags {32} -namingPrefix {33} -debugEnabled {34} -sqlServerEdition {35} -autoShutdownEnabled {36}', parameters('windowsAdminUsername'), parameters('windowsAdminPassword'), parameters('tenantId'), parameters('spnAuthority'), subscription().subscriptionId, resourceGroup().name, parameters('azdataUsername'), parameters('azdataPassword'), parameters('acceptEula'), parameters('registryUsername'), parameters('registryPassword'), parameters('arcDcName'), parameters('location'), parameters('mssqlmiName'), parameters('postgresName'), parameters('postgresWorkerNodeCount'), parameters('postgresDatasize'), parameters('postgresServiceType'), parameters('stagingStorageAccountName'), parameters('workspaceName'), parameters('templateBaseUrl'), parameters('flavor'), parameters('k3sArcDataClusterName'), parameters('k3sArcClusterName'), parameters('aksArcClusterName'), parameters('aksdrArcClusterName'), parameters('githubUser'), parameters('githubBranch'), parameters('vmAutologon'), parameters('rdpPort'), parameters('addsDomainName'), parameters('customLocationRPOID'), parameters('resourceTags'), parameters('namingPrefix'), parameters('debugEnabled'), parameters('sqlServerEdition'), parameters('autoShutdownEnabled'))]"
+                  "commandToExecute": "[format('powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername {0} -tenantId {1} -spnAuthority {2} -subscriptionId {3} -resourceGroup {4} -azdataUsername {5} -acceptEula {6} -registryUsername {7} -arcDcName {8} -azureLocation {9} -mssqlmiName {10} -POSTGRES_NAME {11} -POSTGRES_WORKER_NODE_COUNT {12} -POSTGRES_DATASIZE {13} -POSTGRES_SERVICE_TYPE {14} -stagingStorageAccountName {15} -workspaceName {16} -templateBaseUrl {17} -flavor {18} -k3sArcDataClusterName {19} -k3sArcClusterName {20} -aksArcClusterName {21} -aksdrArcClusterName {22} -githubUser {23} -githubBranch {24} -vmAutologon {25} -rdpPort {26} -addsDomainName {27} -customLocationRPOID {28} -resourceTags {29} -namingPrefix {30} -debugEnabled {31} -sqlServerEdition {32} -autoShutdownEnabled {33}', parameters('windowsAdminUsername'), parameters('tenantId'), parameters('spnAuthority'), subscription().subscriptionId, resourceGroup().name, parameters('azdataUsername'), parameters('acceptEula'), parameters('registryUsername'), parameters('arcDcName'), parameters('location'), parameters('mssqlmiName'), parameters('postgresName'), parameters('postgresWorkerNodeCount'), parameters('postgresDatasize'), parameters('postgresServiceType'), parameters('stagingStorageAccountName'), parameters('workspaceName'), parameters('templateBaseUrl'), parameters('flavor'), parameters('k3sArcDataClusterName'), parameters('k3sArcClusterName'), parameters('aksArcClusterName'), parameters('aksdrArcClusterName'), parameters('githubUser'), parameters('githubBranch'), parameters('vmAutologon'), parameters('rdpPort'), parameters('addsDomainName'), parameters('customLocationRPOID'), parameters('resourceTags'), parameters('namingPrefix'), parameters('debugEnabled'), parameters('sqlServerEdition'), parameters('autoShutdownEnabled'))]"
                 }
               },
               "dependsOn": [
@@ -2003,6 +1999,15 @@
               "dependsOn": [
                 "[resourceId('Microsoft.Compute/virtualMachines', parameters('vmName'))]"
               ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(deployer().objectId, 'Microsoft.Authorization/roleAssignments', 'Key Vault Administrator')]",
+              "properties": {
+                "principalId": "[deployer().objectId]",
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]"
+              }
             },
             {
               "type": "Microsoft.Authorization/roleAssignments",
@@ -2193,16 +2198,23 @@
           },
           "namingPrefix": {
             "value": "[parameters('namingPrefix')]"
+          },
+          "windowsAdminPassword": {
+            "value": "[parameters('windowsAdminPassword')]"
+          },
+          "registryPassword": {
+            "value": "[parameters('registryPassword')]"
           }
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.32.4.45862",
-              "templateHash": "14453387563250772967"
+              "templateHash": "12707130817207447691"
             }
           },
           "parameters": {
@@ -2335,6 +2347,19 @@
               "metadata": {
                 "description": "The naming prefix for the nested virtual machines. Example: ArcBox-Win2k19"
               }
+            },
+            "windowsAdminPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "minLength": 12,
+              "maxLength": 123,
+              "metadata": {
+                "description": "Password for Windows account. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long"
+              }
+            },
+            "registryPassword": {
+              "type": "securestring",
+              "nullable": true
             }
           },
           "variables": {
@@ -2393,8 +2418,8 @@
               }
             ]
           },
-          "resources": [
-            {
+          "resources": {
+            "arcVirtualNetwork": {
               "type": "Microsoft.Network/virtualNetworks",
               "apiVersion": "2022-01-01",
               "name": "[parameters('virtualNetworkName')]",
@@ -2411,12 +2436,12 @@
                 "subnets": "[if(and(equals(parameters('deployBastion'), false()), not(equals(parameters('flavor'), 'DataOps'))), variables('primarySubnet'), if(and(equals(parameters('deployBastion'), false()), equals(parameters('flavor'), 'DataOps')), union(variables('primarySubnet'), variables('dataOpsSubnets')), if(and(equals(parameters('deployBastion'), true()), not(equals(parameters('flavor'), 'DataOps'))), union(variables('primarySubnet'), variables('bastionSubnet')), if(and(equals(parameters('deployBastion'), true()), equals(parameters('flavor'), 'DataOps')), union(variables('primarySubnet'), variables('bastionSubnet'), variables('dataOpsSubnets')), variables('primarySubnet')))))]"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('bastionNetworkSecurityGroupName'))]",
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "bastionNetworkSecurityGroup",
+                "networkSecurityGroup",
+                "policyDeployment"
               ]
             },
-            {
+            "drVirtualNetwork": {
               "condition": "[equals(parameters('flavor'), 'DataOps')]",
               "type": "Microsoft.Network/virtualNetworks",
               "apiVersion": "2022-01-01",
@@ -2444,11 +2469,11 @@
                 ]
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "networkSecurityGroup",
+                "policyDeployment"
               ]
             },
-            {
+            "virtualNetworkName_peering_to_DR_vnet": {
               "condition": "[equals(parameters('flavor'), 'DataOps')]",
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
               "apiVersion": "2022-01-01",
@@ -2463,12 +2488,12 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('drVirtualNetworkName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "arcVirtualNetwork",
+                "drVirtualNetwork",
+                "policyDeployment"
               ]
             },
-            {
+            "drVirtualNetworkName_peering_to_primary_vnet": {
               "condition": "[equals(parameters('flavor'), 'DataOps')]",
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
               "apiVersion": "2022-01-01",
@@ -2483,12 +2508,12 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('drVirtualNetworkName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "arcVirtualNetwork",
+                "drVirtualNetwork",
+                "policyDeployment"
               ]
             },
-            {
+            "networkSecurityGroup": {
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-01-01",
               "name": "[parameters('networkSecurityGroupName')]",
@@ -2602,10 +2627,10 @@
                 ]
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             },
-            {
+            "bastionNetworkSecurityGroup": {
               "condition": "[equals(parameters('deployBastion'), true())]",
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-01-01",
@@ -2732,10 +2757,10 @@
                 ]
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             },
-            {
+            "workspace": {
               "type": "Microsoft.OperationalInsights/workspaces",
               "apiVersion": "2021-06-01",
               "name": "[parameters('workspaceName')]",
@@ -2747,7 +2772,7 @@
                 }
               }
             },
-            {
+            "securityGallery": {
               "type": "Microsoft.OperationsManagement/solutions",
               "apiVersion": "2015-11-01-preview",
               "name": "[variables('security').name]",
@@ -2762,10 +2787,10 @@
                 "publisher": "Microsoft"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+                "workspace"
               ]
             },
-            {
+            "publicIpAddress": {
               "condition": "[equals(parameters('deployBastion'), true())]",
               "type": "Microsoft.Network/publicIPAddresses",
               "apiVersion": "2022-01-01",
@@ -2780,10 +2805,10 @@
                 "name": "Standard"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             },
-            {
+            "bastionHost": {
               "condition": "[equals(parameters('deployBastion'), true())]",
               "type": "Microsoft.Network/bastionHosts",
               "apiVersion": "2023-11-01",
@@ -2797,12 +2822,45 @@
                 "ipConfigurations": "[if(not(equals(parameters('bastionSku'), 'Developer')), createArray(createObject('name', 'IpConf', 'properties', createObject('publicIPAddress', createObject('id', resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))), 'subnet', createObject('id', variables('bastionSubnetRef'))))), null())]"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]",
-                "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))]"
+                "arcVirtualNetwork",
+                "policyDeployment",
+                "publicIpAddress"
               ]
             },
-            {
+            "kv": {
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2023-07-01",
+              "name": "[variables('keyVaultName')]",
+              "dependsOn": [
+                "keyVault"
+              ]
+            },
+            "windowsAdminPassword_kv_secret": {
+              "condition": "[not(empty(parameters('windowsAdminPassword')))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', variables('keyVaultName'), 'windowsAdminPassword')]",
+              "properties": {
+                "value": "[parameters('windowsAdminPassword')]"
+              },
+              "dependsOn": [
+                "keyVault"
+              ]
+            },
+            "registryPassword_kv_secret": {
+              "condition": "[not(empty(parameters('registryPassword')))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', variables('keyVaultName'), 'registryPassword')]",
+              "properties": {
+                "value": "[parameters('registryPassword')]"
+              },
+              "dependsOn": [
+                "keyVault"
+              ]
+            },
+            "policyDeployment": {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "policyDeployment",
@@ -3128,10 +3186,10 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+                "workspace"
               ]
             },
-            {
+            "keyVault": {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "keyVaultDeployment",
@@ -5590,10 +5648,10 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             }
-          ],
+          },
           "outputs": {
             "vnetId": {
               "type": "string",
@@ -5601,7 +5659,7 @@
             },
             "subnetId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '2022-01-01').subnets[0].id]"
+              "value": "[reference('arcVirtualNetwork').subnets[0].id]"
             }
           }
         }
@@ -5895,12 +5953,13 @@
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
           "contentVersion": "1.0.0.0",
           "metadata": {
             "_generator": {
               "name": "bicep",
               "version": "0.32.4.45862",
-              "templateHash": "14453387563250772967"
+              "templateHash": "12707130817207447691"
             }
           },
           "parameters": {
@@ -6033,6 +6092,19 @@
               "metadata": {
                 "description": "The naming prefix for the nested virtual machines. Example: ArcBox-Win2k19"
               }
+            },
+            "windowsAdminPassword": {
+              "type": "securestring",
+              "nullable": true,
+              "minLength": 12,
+              "maxLength": 123,
+              "metadata": {
+                "description": "Password for Windows account. Password must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character. The value must be between 12 and 123 characters long"
+              }
+            },
+            "registryPassword": {
+              "type": "securestring",
+              "nullable": true
             }
           },
           "variables": {
@@ -6091,8 +6163,8 @@
               }
             ]
           },
-          "resources": [
-            {
+          "resources": {
+            "arcVirtualNetwork": {
               "type": "Microsoft.Network/virtualNetworks",
               "apiVersion": "2022-01-01",
               "name": "[parameters('virtualNetworkName')]",
@@ -6109,12 +6181,12 @@
                 "subnets": "[if(and(equals(parameters('deployBastion'), false()), not(equals(parameters('flavor'), 'DataOps'))), variables('primarySubnet'), if(and(equals(parameters('deployBastion'), false()), equals(parameters('flavor'), 'DataOps')), union(variables('primarySubnet'), variables('dataOpsSubnets')), if(and(equals(parameters('deployBastion'), true()), not(equals(parameters('flavor'), 'DataOps'))), union(variables('primarySubnet'), variables('bastionSubnet')), if(and(equals(parameters('deployBastion'), true()), equals(parameters('flavor'), 'DataOps')), union(variables('primarySubnet'), variables('bastionSubnet'), variables('dataOpsSubnets')), variables('primarySubnet')))))]"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('bastionNetworkSecurityGroupName'))]",
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "bastionNetworkSecurityGroup",
+                "networkSecurityGroup",
+                "policyDeployment"
               ]
             },
-            {
+            "drVirtualNetwork": {
               "condition": "[equals(parameters('flavor'), 'DataOps')]",
               "type": "Microsoft.Network/virtualNetworks",
               "apiVersion": "2022-01-01",
@@ -6142,11 +6214,11 @@
                 ]
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "networkSecurityGroup",
+                "policyDeployment"
               ]
             },
-            {
+            "virtualNetworkName_peering_to_DR_vnet": {
               "condition": "[equals(parameters('flavor'), 'DataOps')]",
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
               "apiVersion": "2022-01-01",
@@ -6161,12 +6233,12 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('drVirtualNetworkName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "arcVirtualNetwork",
+                "drVirtualNetwork",
+                "policyDeployment"
               ]
             },
-            {
+            "drVirtualNetworkName_peering_to_primary_vnet": {
               "condition": "[equals(parameters('flavor'), 'DataOps')]",
               "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
               "apiVersion": "2022-01-01",
@@ -6181,12 +6253,12 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('drVirtualNetworkName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "arcVirtualNetwork",
+                "drVirtualNetwork",
+                "policyDeployment"
               ]
             },
-            {
+            "networkSecurityGroup": {
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-01-01",
               "name": "[parameters('networkSecurityGroupName')]",
@@ -6300,10 +6372,10 @@
                 ]
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             },
-            {
+            "bastionNetworkSecurityGroup": {
               "condition": "[equals(parameters('deployBastion'), true())]",
               "type": "Microsoft.Network/networkSecurityGroups",
               "apiVersion": "2022-01-01",
@@ -6430,10 +6502,10 @@
                 ]
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             },
-            {
+            "workspace": {
               "type": "Microsoft.OperationalInsights/workspaces",
               "apiVersion": "2021-06-01",
               "name": "[parameters('workspaceName')]",
@@ -6445,7 +6517,7 @@
                 }
               }
             },
-            {
+            "securityGallery": {
               "type": "Microsoft.OperationsManagement/solutions",
               "apiVersion": "2015-11-01-preview",
               "name": "[variables('security').name]",
@@ -6460,10 +6532,10 @@
                 "publisher": "Microsoft"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+                "workspace"
               ]
             },
-            {
+            "publicIpAddress": {
               "condition": "[equals(parameters('deployBastion'), true())]",
               "type": "Microsoft.Network/publicIPAddresses",
               "apiVersion": "2022-01-01",
@@ -6478,10 +6550,10 @@
                 "name": "Standard"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             },
-            {
+            "bastionHost": {
               "condition": "[equals(parameters('deployBastion'), true())]",
               "type": "Microsoft.Network/bastionHosts",
               "apiVersion": "2023-11-01",
@@ -6495,12 +6567,45 @@
                 "ipConfigurations": "[if(not(equals(parameters('bastionSku'), 'Developer')), createArray(createObject('name', 'IpConf', 'properties', createObject('publicIPAddress', createObject('id', resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))), 'subnet', createObject('id', variables('bastionSubnetRef'))))), null())]"
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]",
-                "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))]"
+                "arcVirtualNetwork",
+                "policyDeployment",
+                "publicIpAddress"
               ]
             },
-            {
+            "kv": {
+              "existing": true,
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2023-07-01",
+              "name": "[variables('keyVaultName')]",
+              "dependsOn": [
+                "keyVault"
+              ]
+            },
+            "windowsAdminPassword_kv_secret": {
+              "condition": "[not(empty(parameters('windowsAdminPassword')))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', variables('keyVaultName'), 'windowsAdminPassword')]",
+              "properties": {
+                "value": "[parameters('windowsAdminPassword')]"
+              },
+              "dependsOn": [
+                "keyVault"
+              ]
+            },
+            "registryPassword_kv_secret": {
+              "condition": "[not(empty(parameters('registryPassword')))]",
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', variables('keyVaultName'), 'registryPassword')]",
+              "properties": {
+                "value": "[parameters('registryPassword')]"
+              },
+              "dependsOn": [
+                "keyVault"
+              ]
+            },
+            "policyDeployment": {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "policyDeployment",
@@ -6826,10 +6931,10 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
+                "workspace"
               ]
             },
-            {
+            "keyVault": {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
               "name": "keyVaultDeployment",
@@ -9288,10 +9393,10 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.Resources/deployments', 'policyDeployment')]"
+                "policyDeployment"
               ]
             }
-          ],
+          },
           "outputs": {
             "vnetId": {
               "type": "string",
@@ -9299,7 +9404,7 @@
             },
             "subnetId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '2022-01-01').subnets[0].id]"
+              "value": "[reference('arcVirtualNetwork').subnets[0].id]"
             }
           }
         }

--- a/azure_jumpstart_arcbox/ARM/azuredeploy.parameters.json
+++ b/azure_jumpstart_arcbox/ARM/azuredeploy.parameters.json
@@ -5,17 +5,11 @@
         "sshRSAPublicKey": {
             "value": "<your RSA public key>"
         },
-        "tenantId": {
-            "value": "<your tenant id>"
-        },
         "windowsAdminUsername": {
             "value": "arcdemo"
         },
         "windowsAdminPassword": {
             "value": "ArcPassword123!!"
-        },
-        "logAnalyticsWorkspaceName": {
-            "value": "<your unique Log Analytics workspace name>"
         },
         "flavor": {
             "value": "ITPro"

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -558,7 +558,7 @@ if ($Env:flavor -ne 'DevOps') {
 
             }
 
-            Restart-VM -Name $ubuntu01vmName
+            Restart-VM -Name $ubuntu01vmName -Force
 
             Invoke-Command -HostName $Ubuntu02VmIp -KeyFilePath "$Env:USERPROFILE\.ssh\id_rsa" -UserName $nestedLinuxUsername -ScriptBlock {
 
@@ -566,7 +566,7 @@ if ($Env:flavor -ne 'DevOps') {
 
             }
 
-            Restart-VM -Name $ubuntu02vmName
+            Restart-VM -Name $ubuntu02vmName -Force
 
         }
 

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -182,10 +182,7 @@ if (-not (Get-SecretVault -Name $KeyVault.VaultName -ErrorAction Ignore)) {
     Register-SecretVault -Name $KeyVault.VaultName -ModuleName Az.KeyVault -VaultParameters @{ AZKVaultName = $KeyVault.VaultName } -DefaultVault
 }
 
-$adminPassword = Get-Secret -Name adminPassword -Secret $adminPassword -AsPlainText
-
-Write-Output "Added the following secrets to Azure Key Vault"
-Get-SecretInfo
+$adminPassword = Get-Secret -Name adminPassword -AsPlainText
 
 # Temporarily disabling Azure VM Auto-shutdown while automation is in progress
 if ($autoShutdownEnabled -eq "true") {

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -182,7 +182,7 @@ if (-not (Get-SecretVault -Name $KeyVault.VaultName -ErrorAction Ignore)) {
     Register-SecretVault -Name $KeyVault.VaultName -ModuleName Az.KeyVault -VaultParameters @{ AZKVaultName = $KeyVault.VaultName } -DefaultVault
 }
 
-$adminPassword = Get-Secret -Name adminPassword -AsPlainText
+$adminPassword = Get-Secret -Name windowsAdminPassword -AsPlainText
 
 # Temporarily disabling Azure VM Auto-shutdown while automation is in progress
 if ($autoShutdownEnabled -eq "true") {

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -1,17 +1,13 @@
 param (
     [string]$adminUsername,
-    [string]$adminPassword,
     [string]$spnClientId,
-    [string]$spnClientSecret,
     [string]$tenantId,
     [string]$spnAuthority,
     [string]$subscriptionId,
     [string]$resourceGroup,
     [string]$azdataUsername,
-    [string]$azdataPassword,
     [string]$acceptEula,
     [string]$registryUsername,
-    [string]$registryPassword,
     [string]$arcDcName,
     [string]$azureLocation,
     [string]$mssqlmiName,
@@ -186,9 +182,7 @@ if (-not (Get-SecretVault -Name $KeyVault.VaultName -ErrorAction Ignore)) {
     Register-SecretVault -Name $KeyVault.VaultName -ModuleName Az.KeyVault -VaultParameters @{ AZKVaultName = $KeyVault.VaultName } -DefaultVault
 }
 
-Set-Secret -Name adminPassword -Secret $adminPassword
-Set-Secret -Name AZDATAPASSWORD -Secret $azdataPassword
-Set-Secret -Name registryPassword -Secret $registryPassword
+$adminPassword = Get-Secret -Name adminPassword -Secret $adminPassword -AsPlainText
 
 Write-Output "Added the following secrets to Azure Key Vault"
 Get-SecretInfo

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -115,22 +115,6 @@ New-Item -Path $Env:ArcBoxTestsDir -ItemType directory -Force
 
 Start-Transcript -Path $Env:ArcBoxLogsDir\Bootstrap.log
 
-if ($vmAutologon -eq "true") {
-
-    Write-Host "Configuring VM Autologon"
-
-    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "AutoAdminLogon" "1"
-    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "DefaultUserName" $adminUsername
-    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "DefaultPassword" $adminPassword
-    if($flavor -eq "DataOps"){
-        Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "DefaultDomainName" "jumpstart.local"
-    }
-} else {
-
-    Write-Host "Not configuring VM Autologon"
-
-}
-
 # Set SyncForegroundPolicy to 1 to ensure that the scheduled task runs after the client VM joins the domain
 Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "SyncForegroundPolicy" 1
 
@@ -183,6 +167,22 @@ if (-not (Get-SecretVault -Name $KeyVault.VaultName -ErrorAction Ignore)) {
 }
 
 $adminPassword = Get-Secret -Name windowsAdminPassword -AsPlainText
+
+if ($vmAutologon -eq "true") {
+
+    Write-Host "Configuring VM Autologon"
+
+    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "AutoAdminLogon" "1"
+    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "DefaultUserName" $adminUsername
+    Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "DefaultPassword" $adminPassword
+    if($flavor -eq "DataOps"){
+        Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" "DefaultDomainName" "jumpstart.local"
+    }
+} else {
+
+    Write-Host "Not configuring VM Autologon"
+
+}
 
 # Temporarily disabling Azure VM Auto-shutdown while automation is in progress
 if ($autoShutdownEnabled -eq "true") {

--- a/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
@@ -79,7 +79,7 @@ if (-not (Get-SecretVault -Name $KeyVault.VaultName -ErrorAction Ignore)) {
 }
 
 # Retrieve Azure Key Vault secrets and store as runtime environment variables
-$AZDATA_PASSWORD = Get-Secret -Name 'AZDATAPASSWORD' -AsPlainText
+$AZDATA_PASSWORD = Get-Secret -Name 'windowsAdminPassword' -AsPlainText
 $Env:AZDATA_PASSWORD = $AZDATA_PASSWORD
 
 # Register Azure providers.

--- a/azure_jumpstart_arcbox/artifacts/RunAfterClientVMADJoin.ps1
+++ b/azure_jumpstart_arcbox/artifacts/RunAfterClientVMADJoin.ps1
@@ -17,7 +17,7 @@ if (-not (Get-SecretVault -Name $KeyVault.VaultName -ErrorAction Ignore)) {
     Register-SecretVault -Name $KeyVault.VaultName -ModuleName Az.KeyVault -VaultParameters @{ AZKVaultName = $KeyVault.VaultName } -DefaultVault
 }
 
-$adminPassword = Get-Secret -Name 'adminPassword' -AsPlainText
+$adminPassword = Get-Secret -Name 'windowsAdminPassword' -AsPlainText
 
 # Get Active Directory Information
 $netbiosname = $Env:addsDomainName.Split('.')[0].ToUpper()

--- a/azure_jumpstart_arcbox/artifacts/SetupADDS.ps1
+++ b/azure_jumpstart_arcbox/artifacts/SetupADDS.ps1
@@ -20,13 +20,63 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
 
-Install-PSResource -Name Az.KeyVault -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+$modules = @("Az.KeyVault", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
 
+foreach ($module in $modules) {
+    Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+}
+
+# Connect to Azure using Managed Identity
 Connect-AzAccount -Identity
+
+# Get the resource group name from the Azure Instance Metadata Service
+$metadataUrl = "http://169.254.169.254/metadata/instance/compute?api-version=2021-02-01"
+$headers = @{ "Metadata" = "true" }
+$response = Invoke-RestMethod -Uri $metadataUrl -Method Get -Headers $headers
+$resourceGroup = $response.resourceGroupName
+
+$KeyVault = Get-AzKeyVault -ResourceGroupName $resourceGroup
+
+# Set Key Vault Name as an environment variable
+[System.Environment]::SetEnvironmentVariable('keyVaultName', $KeyVault.VaultName, [System.EnvironmentVariableTarget]::Machine)
+
+# Import required module
+Import-Module Microsoft.PowerShell.SecretManagement
+
+# Register the Azure Key Vault as a secret vault if not already registered
+# Ensure you have installed the SecretManagement and SecretStore modules along with the Key Vault extension
+
+if (-not (Get-SecretVault -Name $KeyVault.VaultName -ErrorAction Ignore)) {
+    Register-SecretVault -Name $KeyVault.VaultName -ModuleName Az.KeyVault -VaultParameters @{ AZKVaultName = $KeyVault.VaultName } -DefaultVault
+}
 
 # Fetch windowsAdminPassword from Key Vault (assumes $env:KeyVaultName is defined)
 $windowsAdminPasswordSecret = Get-Secret -Name windowsAdminPassword -AsPlainText
 $secureDomainAdminPassword = $windowsAdminPasswordSecret | ConvertTo-SecureString -AsPlainText -Force
+
+# Set Diagnostic Data settings
+
+$telemetryPath = "HKLM:\Software\Policies\Microsoft\Windows\DataCollection"
+$telemetryProperty = "AllowTelemetry"
+$telemetryValue = 3
+
+$oobePath = "HKLM:\Software\Policies\Microsoft\Windows\OOBE"
+$oobeProperty = "DisablePrivacyExperience"
+$oobeValue = 1
+
+# Create the registry key and set the value for AllowTelemetry
+if (-not (Test-Path $telemetryPath)) {
+    New-Item -Path $telemetryPath -Force | Out-Null
+}
+Set-ItemProperty -Path $telemetryPath -Name $telemetryProperty -Value $telemetryValue
+
+# Create the registry key and set the value for DisablePrivacyExperience
+if (-not (Test-Path $oobePath)) {
+    New-Item -Path $oobePath -Force | Out-Null
+}
+Set-ItemProperty -Path $oobePath -Name $oobeProperty -Value $oobeValue
+
+Write-Host "Registry keys and values for Diagnostic Data settings have been set successfully."
 
 # Enable ADDS windows feature to setup domain forest
 Install-WindowsFeature -Name AD-Domain-Services -IncludeManagementTools

--- a/azure_jumpstart_arcbox/artifacts/WinGet.ps1
+++ b/azure_jumpstart_arcbox/artifacts/WinGet.ps1
@@ -4,6 +4,7 @@ $Env:ArcBoxDir = 'C:\ArcBox'
 $Env:ArcBoxLogsDir = "$Env:ArcBoxDir\Logs"
 $tenantId = $env:tenantId
 $subscriptionId = $env:subscriptionId
+$resourceGroup = $env:resourceGroup
 
 $logFilePath = Join-Path -Path $Env:ArcBoxLogsDir -ChildPath ('WinGet-provisioning-' + (Get-Date -Format 'yyyyMMddHHmmss') + '.log')
 

--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -286,7 +286,7 @@ resource vmRoleAssignment_KeyVaultAdministrator 'Microsoft.Authorization/roleAss
 
 // Add role assignment for the deploy user: Azure Key Vault Administrator role
 resource deployerRoleAssignment_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(deployer().objectId, 'Microsoft.Authorization/roleAssignments', 'Key Vault Administrator')
+  name: guid(resourceGroup().id,deployer().objectId, resourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
   scope: resourceGroup()
   properties: {
     principalId: deployer().objectId

--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -34,13 +34,9 @@ param spnAuthority string = environment().authentication.loginEndpoint
 param tenantId string
 param azdataUsername string = 'arcdemo'
 
-@secure()
-param azdataPassword string
 param acceptEula string = 'yes'
 param registryUsername string = 'registryUser'
 
-@secure()
-param registryPassword string = newGuid()
 param arcDcName string = 'arcdatactrl'
 param mssqlmiName string = 'arcsqlmidemo'
 
@@ -271,7 +267,7 @@ resource vmBootstrap 'Microsoft.Compute/virtualMachines/extensions@2022-03-01' =
       fileUris: [
         uri(templateBaseUrl, 'artifacts/Bootstrap.ps1')
       ]
-      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername ${windowsAdminUsername} -adminPassword ${windowsAdminPassword} -tenantId ${tenantId} -spnAuthority ${spnAuthority} -subscriptionId ${subscription().subscriptionId} -resourceGroup ${resourceGroup().name} -azdataUsername ${azdataUsername} -azdataPassword ${azdataPassword} -acceptEula ${acceptEula} -registryUsername ${registryUsername} -registryPassword ${registryPassword} -arcDcName ${arcDcName} -azureLocation ${location} -mssqlmiName ${mssqlmiName} -POSTGRES_NAME ${postgresName} -POSTGRES_WORKER_NODE_COUNT ${postgresWorkerNodeCount} -POSTGRES_DATASIZE ${postgresDatasize} -POSTGRES_SERVICE_TYPE ${postgresServiceType} -stagingStorageAccountName ${stagingStorageAccountName} -workspaceName ${workspaceName} -templateBaseUrl ${templateBaseUrl} -flavor ${flavor} -k3sArcDataClusterName ${k3sArcDataClusterName} -k3sArcClusterName ${k3sArcClusterName} -aksArcClusterName ${aksArcClusterName} -aksdrArcClusterName ${aksdrArcClusterName} -githubUser ${githubUser} -githubBranch ${githubBranch} -vmAutologon ${vmAutologon} -rdpPort ${rdpPort} -addsDomainName ${addsDomainName} -customLocationRPOID ${customLocationRPOID} -resourceTags ${resourceTags} -namingPrefix ${namingPrefix} -debugEnabled ${debugEnabled} -sqlServerEdition ${sqlServerEdition} -autoShutdownEnabled ${autoShutdownEnabled}'
+      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File Bootstrap.ps1 -adminUsername ${windowsAdminUsername} -tenantId ${tenantId} -spnAuthority ${spnAuthority} -subscriptionId ${subscription().subscriptionId} -resourceGroup ${resourceGroup().name} -azdataUsername ${azdataUsername} -acceptEula ${acceptEula} -registryUsername ${registryUsername} -arcDcName ${arcDcName} -azureLocation ${location} -mssqlmiName ${mssqlmiName} -POSTGRES_NAME ${postgresName} -POSTGRES_WORKER_NODE_COUNT ${postgresWorkerNodeCount} -POSTGRES_DATASIZE ${postgresDatasize} -POSTGRES_SERVICE_TYPE ${postgresServiceType} -stagingStorageAccountName ${stagingStorageAccountName} -workspaceName ${workspaceName} -templateBaseUrl ${templateBaseUrl} -flavor ${flavor} -k3sArcDataClusterName ${k3sArcDataClusterName} -k3sArcClusterName ${k3sArcClusterName} -aksArcClusterName ${aksArcClusterName} -aksdrArcClusterName ${aksdrArcClusterName} -githubUser ${githubUser} -githubBranch ${githubBranch} -vmAutologon ${vmAutologon} -rdpPort ${rdpPort} -addsDomainName ${addsDomainName} -customLocationRPOID ${customLocationRPOID} -resourceTags ${resourceTags} -namingPrefix ${namingPrefix} -debugEnabled ${debugEnabled} -sqlServerEdition ${sqlServerEdition} -autoShutdownEnabled ${autoShutdownEnabled}'
     }
   }
 }

--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -286,7 +286,7 @@ resource vmRoleAssignment_KeyVaultAdministrator 'Microsoft.Authorization/roleAss
 
 // Add role assignment for the deploy user: Azure Key Vault Administrator role
 resource deployerRoleAssignment_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(deployer().objectId, 'Microsoft.Authorization/roleAssignments', 'Administrator')
+  name: guid(deployer().objectId, 'Microsoft.Authorization/roleAssignments', 'Key Vault Administrator')
   scope: resourceGroup()
   properties: {
     principalId: deployer().objectId

--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -272,7 +272,7 @@ resource vmBootstrap 'Microsoft.Compute/virtualMachines/extensions@2022-03-01' =
   }
 }
 
-// Add role assignment for the VM: Azure Key Vault Secret Officer role
+// Add role assignment for the VM: Azure Key Vault Administrator role
 resource vmRoleAssignment_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(vm.id, 'Microsoft.Authorization/roleAssignments', 'Administrator')
   scope: resourceGroup()
@@ -281,6 +281,16 @@ resource vmRoleAssignment_KeyVaultAdministrator 'Microsoft.Authorization/roleAss
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
     principalType: 'ServicePrincipal'
 
+  }
+}
+
+// Add role assignment for the deploy user: Azure Key Vault Administrator role
+resource deployerRoleAssignment_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(deployer().objectId, 'Microsoft.Authorization/roleAssignments', 'Administrator')
+  scope: resourceGroup()
+  properties: {
+    principalId: deployer().objectId
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
   }
 }
 

--- a/azure_jumpstart_arcbox/bicep/main.bicep
+++ b/azure_jumpstart_arcbox/bicep/main.bicep
@@ -12,7 +12,7 @@ param windowsAdminUsername string
 @minLength(12)
 @maxLength(123)
 @secure()
-param windowsAdminPassword string
+param windowsAdminPassword string  = newGuid()
 
 @description('Enable automatic logon into ArcBox Virtual Machine')
 param vmAutologon bool = true

--- a/azure_jumpstart_arcbox/bicep/main.bicep
+++ b/azure_jumpstart_arcbox/bicep/main.bicep
@@ -21,7 +21,7 @@ param vmAutologon bool = true
 param rdpPort string = '3389'
 
 @description('Name for your log analytics workspace')
-param logAnalyticsWorkspaceName string
+param logAnalyticsWorkspaceName string = 'ArcBox-la'
 
 @description('The flavor of ArcBox you want to deploy. Valid values are: \'Full\', \'ITPro\', \'DevOps\', \'DataOps\'')
 @allowed([

--- a/azure_jumpstart_arcbox/bicep/main.bicep
+++ b/azure_jumpstart_arcbox/bicep/main.bicep
@@ -99,6 +99,9 @@ param enableAzureSpotPricing bool = false
 ])
 param zones string = '1'
 
+@secure()
+param registryPassword string = newGuid()
+
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_arcbox/'
 var aksArcDataClusterName = '${namingPrefix}-AKS-Data-${guid}'
 var aksDrArcDataClusterName = '${namingPrefix}-AKS-DR-Data-${guid}'
@@ -181,7 +184,6 @@ module clientVmDeployment 'clientVm/clientVm.bicep' = {
   params: {
     windowsAdminUsername: windowsAdminUsername
     windowsAdminPassword: windowsAdminPassword
-    azdataPassword: windowsAdminPassword
     tenantId: tenantId
     workspaceName: logAnalyticsWorkspaceName
     stagingStorageAccountName: toLower(stagingStorageAccountDeployment.outputs.storageAccountName)
@@ -235,6 +237,8 @@ module mgmtArtifactsAndPolicyDeployment 'mgmt/mgmtArtifacts.bicep' = {
     location: location
     resourceTags: resourceTags
     namingPrefix: namingPrefix
+    windowsAdminPassword: windowsAdminPassword
+    registryPassword: registryPassword
   }
 }
 

--- a/azure_jumpstart_arcbox/bicep/mgmt/addsVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/mgmt/addsVm.bicep
@@ -14,7 +14,7 @@ param windowsAdminUsername string = 'arcdemo'
 param windowsAdminPassword string
 
 @description('The Windows version for the VM. This will pick a fully patched image of this given Windows version')
-param windowsOSVersion string = '2022-datacenter-g2'
+param windowsOSVersion string = '2025-datacenter-g2'
 
 @description('Location for all resources')
 param azureLocation string = resourceGroup().location

--- a/azure_jumpstart_arcbox/bicep/mgmt/addsVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/mgmt/addsVm.bicep
@@ -120,6 +120,9 @@ resource clientVM 'Microsoft.Compute/virtualMachines@2022-03-01' = {
       }
     }
   }
+  identity: {
+    type: 'SystemAssigned'
+  }
 }
 
 resource vmName_DeployADDS 'Microsoft.Compute/virtualMachines/extensions@2022-03-01' = {
@@ -135,8 +138,28 @@ resource vmName_DeployADDS 'Microsoft.Compute/virtualMachines/extensions@2022-03
       fileUris: [
         uri(templateBaseUrl, 'artifacts/SetupADDS.ps1')
       ]
-      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File SetupADDS.ps1 -domainName ${addsDomainName} -domainAdminUsername ${windowsAdminUsername} -domainAdminPassword ${windowsAdminPassword} -templateBaseUrl ${templateBaseUrl}'
+      commandToExecute: 'powershell.exe -ExecutionPolicy Bypass -File SetupADDS.ps1 -domainName ${addsDomainName} -domainAdminUsername ${windowsAdminUsername} -templateBaseUrl ${templateBaseUrl}'
     }
+  }
+}
+
+// Role assignment for Reader
+resource vmReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(clientVM.id, 'reader')
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')
+    principalId: clientVM.identity.principalId
+  }
+}
+
+// Role assignment for Key Vault Secret Reader
+resource vmKeyVaultSecretReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: guid(clientVM.id, 'keyVaultSecretReader')
+  scope: resourceGroup()
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
+    principalId: clientVM.identity.principalId
   }
 }
 


### PR DESCRIPTION
This pull request includes multiple changes to the `azure_jumpstart_arcbox` project, focusing on simplifying parameter handling, enhancing security, and improving role assignments. The most important changes are summarized below:

### Parameter Handling Simplification:
* Removed several parameters (`adminPassword`, `spnClientSecret`, `azdataPassword`, `registryPassword`) from `Bootstrap.ps1` and `clientVm.bicep`, simplifying the scripts by reducing the number of required inputs. [[1]](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707L3-L14) [[2]](diffhunk://#diff-db7ddb891dea059a7a5630ee36842f00a9d7fa9e6e96a1873867bdcf3a7dda58L37-L43)
* Updated the `commandToExecute` in `clientVm.bicep` to reflect the removal of these parameters.

### Security Enhancements:
* Changed the retrieval of `AZDATA_PASSWORD` from Azure Key Vault to use `windowsAdminPassword` instead in `DataOpsLogonScript.ps1`.
* Added secure default values for `windowsAdminPassword` and `registryPassword` using `newGuid()` in `main.bicep`. [[1]](diffhunk://#diff-5a585802eb85810bd727cbf66096ef340c6617d731c97a8a4c200e3cca5e8231L15-R15) [[2]](diffhunk://#diff-5a585802eb85810bd727cbf66096ef340c6617d731c97a8a4c200e3cca5e8231R102-R104)
* Stored `windowsAdminPassword` and `registryPassword` in Azure Key Vault as secrets in `mgmtArtifacts.bicep`.

### Role Assignments:
* Added a new role assignment for the deploy user as an Azure Key Vault Administrator in `clientVm.bicep`.

### VM Management:
* Forced VM restarts in `ArcServersLogonScript.ps1` to ensure the changes take effect immediately.

These changes collectively enhance the security and manageability of the Azure Jumpstart ArcBox deployment scripts.


- Fixes https://github.com/microsoft/azure_arc/issues/2904
- Docs update https://github.com/Azure/arc_jumpstart_docs/pull/505