### PR TITLE
Arcbox issue 2934

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -629,7 +629,7 @@ if ($Env:flavor -ne 'DevOps') {
             $vm = $PSItem
 
             # Install Dependency Agent
-            New-AzConnectedMachineExtension -ResourceGroupName $resourceGroup -MachineName $vm -Name DependencyAgentWindows -Publisher Microsoft.Azure.Monitor -Type DependencyAgentWindows -Location $azureLocation -Settings @{} -Force -NoWait
+            $null = New-AzConnectedMachineExtension -ResourceGroupName $using:resourceGroup -MachineName $vm -Name DependencyAgentWindows -Publisher Microsoft.Azure.Monitoring.DependencyAgent -ExtensionType DependencyAgentWindows -Location $using:azureLocation -Settings @{"enableAMA" = $true} -NoWait
 
         }
 

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -620,6 +620,19 @@ if ($Env:flavor -ne 'DevOps') {
         $UbuntuSessions = New-PSSession -HostName $Ubuntu01VmIp, $Ubuntu02VmIp -KeyFilePath "$Env:USERPROFILE\.ssh\id_rsa" -UserName $nestedLinuxUsername
         Invoke-JSSudoCommand -Session $UbuntuSessions -Command "sh /home/$nestedLinuxUsername/installArcAgentModifiedUbuntu.sh"
 
+        Write-Header 'Installing Dependency Agent for Arc-enabled Windows servers'
+        $VMs = @("$namingPrefix-SQL", "$namingPrefix-Win2K22", "$namingPrefix-Win2K25")
+        $VMs | ForEach-Object -Parallel {
+
+            $null = Connect-AzAccount -Identity -Tenant $using:tenantId -Subscription $using:subscriptionId -Scope Process -WarningAction SilentlyContinue
+
+            $vm = $PSItem
+
+            # Install Dependency Agent
+            New-AzConnectedMachineExtension -ResourceGroupName $resourceGroup -MachineName $vm -Name DependencyAgentWindows -Publisher Microsoft.Azure.Monitor -Type DependencyAgentWindows -Location $azureLocation -Settings @{} -Force -NoWait
+
+        }
+
         Write-Header 'Enabling SSH access and triggering update assessment for Arc-enabled servers'
         $VMs = @("$namingPrefix-SQL", "$namingPrefix-Ubuntu-01", "$namingPrefix-Ubuntu-02", "$namingPrefix-Win2K22", "$namingPrefix-Win2K25")
         $VMs | ForEach-Object -Parallel {

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -628,6 +628,8 @@ if ($Env:flavor -ne 'DevOps') {
 
             $vm = $PSItem
 
+            Write-Output "Invoking installation on $vm"
+
             # Install Dependency Agent
             $null = New-AzConnectedMachineExtension -ResourceGroupName $using:resourceGroup -MachineName $vm -Name DependencyAgentWindows -Publisher Microsoft.Azure.Monitoring.DependencyAgent -ExtensionType DependencyAgentWindows -Location $using:azureLocation -Settings @{"enableAMA" = $true} -NoWait
 

--- a/azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep
+++ b/azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep
@@ -21,7 +21,7 @@ param tagsRoleDefinitionId string = '/subscriptions/${subscription().subscriptio
 var policies = [
   {
     name: '(ArcBox) Enable Azure Monitor for Hybrid VMs with AMA'
-    definitionId: '/providers/Microsoft.Authorization/policySetDefinitions/2b00397d-c309-49c4-aa5a-f0b2c5bc6321'
+    definitionId: '/providers/Microsoft.Authorization/policySetDefinitions/59e9c3eb-d8df-473b-8059-23fd38ddd0f0'
     flavors: [
       'ITPro'
     ]

--- a/azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep
+++ b/azure_jumpstart_arcbox/bicep/mgmt/policyAzureArc.bicep
@@ -4,7 +4,7 @@ param azureLocation string
 @description('Name of your log analytics workspace')
 param logAnalyticsWorkspaceId string
 
-@description('The flavor of ArcBox you want to deploy. Valid values are: \'Full\', \'ITPro\', \'DevOps\'')
+@description('The flavor of ArcBox you want to deploy. Valid values are: \'DataOps\', \'DevOps\', \'ITPro\'')
 param flavor string
 
 @description('Tags to assign for all ArcBox resources')
@@ -21,9 +21,8 @@ param tagsRoleDefinitionId string = '/subscriptions/${subscription().subscriptio
 var policies = [
   {
     name: '(ArcBox) Enable Azure Monitor for Hybrid VMs with AMA'
-    definitionId: '/providers/Microsoft.Authorization/policySetDefinitions/59e9c3eb-d8df-473b-8059-23fd38ddd0f0'
+    definitionId: '/providers/Microsoft.Authorization/policySetDefinitions/2b00397d-c309-49c4-aa5a-f0b2c5bc6321'
     flavors: [
-      'Full'
       'ITPro'
     ]
     roleDefinition:  [
@@ -36,7 +35,7 @@ var policies = [
         value: logAnalyticsWorkspaceId
       }
       enableProcessesAndDependencies: {
-        value: true
+        value: false
       }
     }
   }
@@ -44,7 +43,6 @@ var policies = [
     name: '(ArcBox) Enable Microsoft Defender on Kubernetes clusters'
     definitionId: '/providers/Microsoft.Authorization/policyDefinitions/708b60a6-d253-4fe0-9114-4be4c00f012c'
     flavors: [
-      'Full'
       'DevOps'
     ]
     roleDefinition: '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293'


### PR DESCRIPTION
This pull request includes several changes to the `azure_jumpstart_arcbox` project, focusing on the installation of dependency agents, policy configurations, and parameter descriptions. The most important changes include adding a new installation step for dependency agents and modifying policy configurations.

### Installation and Configuration:

* Added a step to install the Dependency Agent for Arc-enabled Windows servers in the `ArcServersLogonScript.ps1` file. This includes connecting to Azure and invoking the installation on specified VMs.

### Parameter Descriptions:

* Updated the description of the `flavor` parameter to include 'DataOps' as a valid value in the `policyAzureArc.bicep` file.

### Policy Configurations:

* Removed 'Full' as a valid flavor for the policy to enable Azure Monitor for Hybrid VMs with AMA in the `policyAzureArc.bicep` file.
* Changed the `enableProcessesAndDependencies` value from `true` to `false` in the policy configuration for enabling Azure Monitor in the `policyAzureArc.bicep` file.
* Removed 'Full' as a valid flavor for the policy to enable Microsoft Defender on Kubernetes clusters in the `policyAzureArc.bicep` file.

- Fixes #2934 
