### PR TITLE
use contoso-motors configs just for that scenario

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -169,9 +169,15 @@ if ($scenario -eq "contoso_supermarket") {
 #####################################################################
 # Get clusters config files
 #####################################################################
-if($scenario -eq "contoso_hypermarket" -or $scenario -eq "contoso_motors"){
+if($scenario -eq "contoso_motors"){
     Get-K3sConfigFileContosoMotors 
     Merge-K3sConfigFilesContosoMotors
+    Set-K3sClusters
+}
+
+if($scenario -eq "contoso_hypermarket"){
+    Get-K3sConfigFile
+    Merge-K3sConfigFiles
     Set-K3sClusters
 }
 


### PR DESCRIPTION
this is an attempt to fix the error I contribured earlier where a hypermarket deploy would use the K3s-related tasks for the contoso-motors scenario.