### PR TITLE
HciBox issue 2998 - added resource tag default values

### DIFF
--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Configure-AKSWorkloadCluster.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Configure-AKSWorkloadCluster.ps1
@@ -1,9 +1,9 @@
 $WarningPreference = "SilentlyContinue"
-$ErrorActionPreference = "Stop" 
+$ErrorActionPreference = "Stop"
 $ProgressPreference = 'SilentlyContinue'
 
-# Set groupObjectID to the object ID of the Microsoft Entra ID group that will be granted access to the AKS workload cluster. 
-#$groupObjectID="aaaaaaa-bbbb-cccc-db62-fffssfff" # Uncomment this line and change the value to your Microsoft Entra ID group id 
+# Set groupObjectID to the object ID of the Microsoft Entra ID group that will be granted access to the AKS workload cluster.
+#$groupObjectID="aaaaaaa-bbbb-cccc-db62-fffssfff" # Uncomment this line and change the value to your Microsoft Entra ID group id
 
 # Set paths
 $Env:HCIBoxDir = "C:\HCIBox"
@@ -27,7 +27,7 @@ $lnetName = "hcibox-aks-lnet-vlan110"
 $customLocName = $HCIBoxConfig.rbCustomLocationName
 $WarningPreference = "SilentlyContinue"
 $ErrorActionPreference = "SilentlyContinue"
-Invoke-Command -ComputerName "$($HCIBoxConfig.NodeHostConfig[0].Hostname).$($HCIBoxConfig.SDNDomainFQDN)" -Credential $domainCred -Authentication CredSSP -ArgumentList $HCIBoxConfig -ScriptBlock {
+Invoke-Command -VMName "$($HCIBoxConfig.NodeHostConfig[0].Hostname)" -Credential $domainCred -ArgumentList $HCIBoxConfig -ScriptBlock {
     $HCIBoxConfig = $args[0]
     az login --service-principal --username $using:spnClientID --password=$using:spnSecret --tenant $using:spnTenantId
     az config set extension.use_dynamic_install=yes_without_prompt | Out-Null
@@ -35,7 +35,7 @@ Invoke-Command -ComputerName "$($HCIBoxConfig.NodeHostConfig[0].Hostname).$($HCI
     az extension add --name stack-hci-vm
     $customLocationID=(az customlocation show --resource-group $using:rg --name $using:customLocName --query id -o tsv)
     $switchName='"ConvergedSwitch(hci)"'
-    
+
     $addressPrefixes = $HCIBoxConfig.AKSIPPrefix
     $gateway = $HCIBoxConfig.AKSGWIP
     $dnsServers = $HCIBoxConfig.AKSDNSIP

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Configure-VMLogicalNetwork.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Configure-VMLogicalNetwork.ps1
@@ -1,5 +1,5 @@
 $WarningPreference = "SilentlyContinue"
-$ErrorActionPreference = "Stop" 
+$ErrorActionPreference = "Stop"
 $ProgressPreference = 'SilentlyContinue'
 
 # Set paths
@@ -21,7 +21,7 @@ $location = $env:azureLocation
 $customLocName = $HCIBoxConfig.rbCustomLocationName
 
 # Create logical networks
-Invoke-Command -ComputerName "$($HCIBoxConfig.NodeHostConfig[0].Hostname).$($HCIBoxConfig.SDNDomainFQDN)" -Credential $domainCred -Authentication CredSSP -ArgumentList $HCIBoxConfig -ScriptBlock {
+Invoke-Command -VMName "$($HCIBoxConfig.NodeHostConfig[0].Hostname)" -Credential $domainCred -ArgumentList $HCIBoxConfig -ScriptBlock {
     $HCIBoxConfig = $args[0]
     az login --service-principal --username $using:spnClientID --password=$using:spnSecret --tenant $using:spnTenantId
     az config set extension.use_dynamic_install=yes_without_prompt

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1
@@ -1910,6 +1910,31 @@ catch {
     Write-Output "Validation failed. Re-run New-AzResourceGroupDeployment to retry. Error: $($_.Exception.Message)"
 }
 
+
+    # Adding known governance tags for avoiding disruptions to the deployment. These resources are not created by the Bicep template for HCIBox, hence the need to add them as part of the automation.
+    $tags = @{
+        'CostControl' = 'Ignore'
+        'SecurityControl' = 'Ignore'
+    }
+    Get-AzKeyVault -ResourceGroupName $env:resourceGroup |
+    ForEach-Object {
+
+        $null = Set-AzResource -ResourceName $PSItem.VaultName -ResourceGroupName $env:resourceGroup -ResourceType 'Microsoft.KeyVault/vaults' -Tag $tags -Force
+
+    }
+    Get-AzStorageAccount -ResourceGroupName $env:resourceGroup |
+    ForEach-Object {
+
+        $null = Set-AzResource -ResourceName $PSItem.StorageAccountName -ResourceGroupName $env:resourceGroup -ResourceType 'Microsoft.Storage/storageAccounts' -Tag $tags -Force
+
+    }
+    Get-AzDisk -ResourceGroupName $env:resourceGroup |
+    ForEach-Object {
+
+        $null = Set-AzResource -ResourceName $PSItem.Name -ResourceGroupName $env:resourceGroup -ResourceType 'Microsoft.Compute/disks' -Tag $tags -Force
+
+    }
+
 Write-Host "[Build cluster - Step 11/11] Run cluster deployment..." -ForegroundColor Green
 
 if ($ClusterValidationDeployment.ProvisioningState -eq "Succeeded") {

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/tests/Invoke-Test.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/tests/Invoke-Test.ps1
@@ -73,11 +73,15 @@ function Wait-AzLocalClusterConnectivity {
     }
 }
 
-# Wait for the deployment to complete
-Wait-AzDeployment -ResourceGroupName $env:resourceGroup -DeploymentName hcicluster-deploy
+if ("True" -eq $env:autoDeployClusterResource) {
 
-# Wait for the cluster to be connected
-Wait-AzLocalClusterConnectivity -ResourceGroupName $env:resourceGroup -ClusterName $HCIBoxConfig.ClusterName
+    # Wait for the deployment to complete
+    Wait-AzDeployment -ResourceGroupName $env:resourceGroup -DeploymentName hcicluster-deploy
+
+    # Wait for the cluster to be connected
+    Wait-AzLocalClusterConnectivity -ResourceGroupName $env:resourceGroup -ClusterName $HCIBoxConfig.ClusterName
+
+}
 
 Invoke-Pester -Path "$Env:HCIBoxTestsDir\common.tests.ps1" -Output Detailed -PassThru -OutVariable tests_common
 $tests_passed = $tests_common.Passed.Count

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/tests/Invoke-Test.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/tests/Invoke-Test.ps1
@@ -13,6 +13,9 @@ function Wait-AzDeployment {
         [Parameter(Mandatory = $true)]
         [string]$DeploymentName,
 
+        [Parameter(Mandatory = $true)]
+        [string]$ClusterName,
+
         [int]$TimeoutMinutes = 240  # Default timeout of 4 hours
     )
 
@@ -90,7 +93,7 @@ function Wait-AzLocalClusterConnectivity {
 if ('True' -eq $env:autoDeployClusterResource) {
 
     # Wait for the deployment to complete
-    Wait-AzDeployment -ResourceGroupName $env:resourceGroup -DeploymentName hcicluster-deploy
+    Wait-AzDeployment -ResourceGroupName $env:resourceGroup -DeploymentName hcicluster-deploy -ClusterName $HCIBoxConfig.ClusterName
 
     # Wait for the cluster to be connected
     Wait-AzLocalClusterConnectivity -ResourceGroupName $env:resourceGroup -ClusterName $HCIBoxConfig.ClusterName

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/tests/Invoke-Test.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/tests/Invoke-Test.ps1
@@ -7,10 +7,10 @@ $HCIBoxConfig = Import-PowerShellDataFile -Path $Env:HCIBoxConfigFile
 
 function Wait-AzDeployment {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$ResourceGroupName,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$DeploymentName,
 
         [int]$TimeoutMinutes = 240  # Default timeout of 4 hours
@@ -19,32 +19,39 @@ function Wait-AzDeployment {
     $startTime = Get-Date
     $endTime = $startTime.AddMinutes($TimeoutMinutes)
 
-    Write-Host "Waiting for deployment '$DeploymentName' in resource group '$ResourceGroupName' to complete..."
+    $clusterObject = Get-AzStackHciCluster -ResourceGroupName $ResourceGroupName -Name $ClusterName -ErrorAction Ignore
 
-    while ($true) {
-        $deployment = Get-AzResourceGroupDeployment -Name $DeploymentName -ResourceGroupName $ResourceGroupName
+    if ($clusterObject) {
 
-        if ($deployment.ProvisioningState -ne "InProgress") {
-            Write-Host "Deployment completed with state: $($deployment.ProvisioningState)"
-            return $deployment.ProvisioningState
+        Write-Host "Waiting for deployment '$DeploymentName' in resource group '$ResourceGroupName' to complete..."
+
+        while ($true) {
+            $deployment = Get-AzResourceGroupDeployment -Name $DeploymentName -ResourceGroupName $ResourceGroupName
+
+            if ($deployment.ProvisioningState -ne 'InProgress') {
+                Write-Host "Deployment completed with state: $($deployment.ProvisioningState)"
+                return $deployment.ProvisioningState
+            }
+
+            if (Get-Date -gt $endTime) {
+                Write-Host 'Timeout reached. Deployment still in progress.'
+                return 'Timeout'
+            }
+
+            Write-Host 'Deployment still in progress. Checking again in 1 minute...'
+            Start-Sleep -Seconds 60
         }
-
-        if (Get-Date -gt $endTime) {
-            Write-Host "Timeout reached. Deployment still in progress."
-            return "Timeout"
-        }
-
-        Write-Host "Deployment still in progress. Checking again in 1 minute..."
-        Start-Sleep -Seconds 60
+    } else {
+        Write-Host "Cluster '$ClusterName' does not exist - skipping deployment status check..."
     }
 }
 
 function Wait-AzLocalClusterConnectivity {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$ResourceGroupName,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$ClusterName,
 
         [int]$TimeoutMinutes = 60  # Default timeout of 60 minutes
@@ -53,27 +60,34 @@ function Wait-AzLocalClusterConnectivity {
     $startTime = Get-Date
     $endTime = $startTime.AddMinutes($TimeoutMinutes)
 
-    Write-Host "Waiting for cluster '$ClusterName' in resource group '$ResourceGroupName' to be 'Connected'..."
+    $clusterObject = Get-AzStackHciCluster -ResourceGroupName $ResourceGroupName -Name $ClusterName -ErrorAction Ignore
 
-    while ($true) {
-        $clusterObject = Get-AzStackHciCluster -ResourceGroupName $ResourceGroupName -Name $ClusterName
+    if ($clusterObject) {
 
-        if ($clusterObject -and $clusterObject.ConnectivityStatus -eq "Connected") {
-            Write-Host "Cluster '$ClusterName' is now Connected."
-            return $true
+        Write-Host "Waiting for cluster '$ClusterName' in resource group '$ResourceGroupName' to be 'Connected'..."
+
+        while ($true) {
+            $clusterObject = Get-AzStackHciCluster -ResourceGroupName $ResourceGroupName -Name $ClusterName -ErrorAction Ignore
+
+            if ($clusterObject -and $clusterObject.ConnectivityStatus -eq 'Connected') {
+                Write-Host "Cluster '$ClusterName' is now Connected."
+                return $true
+            }
+
+            if ([DateTime]::Now -gt $endTime) {
+                Write-Host "Timeout reached. Cluster '$ClusterName' is still not Connected."
+                return $false
+            }
+
+            Write-Host "Cluster '$ClusterName' is still not Connected. Checking again in 30 seconds..."
+            Start-Sleep -Seconds 30
         }
-
-        if ([DateTime]::Now -gt $endTime) {
-            Write-Host "Timeout reached. Cluster '$ClusterName' is still not Connected."
-            return $false
-        }
-
-        Write-Host "Cluster '$ClusterName' is still not Connected. Checking again in 30 seconds..."
-        Start-Sleep -Seconds 30
+    } else {
+        Write-Host "Cluster '$ClusterName' does not exist - skipping connectivity check..."
     }
 }
 
-if ("True" -eq $env:autoDeployClusterResource) {
+if ('True' -eq $env:autoDeployClusterResource) {
 
     # Wait for the deployment to complete
     Wait-AzDeployment -ResourceGroupName $env:resourceGroup -DeploymentName hcicluster-deploy
@@ -96,7 +110,7 @@ $tests_failed = $tests_failed + $tests_hci.Failed.Count
 Write-Output "Tests succeeded: $tests_passed"
 Write-Output "Tests failed: $tests_failed"
 
-Write-Output "Exporting deployment test results to resource group tag DeploymentStatus"
+Write-Output 'Exporting deployment test results to resource group tag DeploymentStatus'
 
 $DeploymentStatusString = "Tests succeeded: $tests_passed Tests failed: $tests_failed"
 
@@ -119,9 +133,9 @@ if ($null -ne $tags) {
 }
 
 $null = Set-AzResourceGroup -ResourceGroupName $env:resourceGroup -Tag $tags
-$null = Set-AzResource -ResourceName $env:computername -ResourceGroupName $env:resourceGroup -ResourceType "microsoft.compute/virtualmachines" -Tag $tags -Force
+$null = Set-AzResource -ResourceName $env:computername -ResourceGroupName $env:resourceGroup -ResourceType 'microsoft.compute/virtualmachines' -Tag $tags -Force
 
-Write-Header "Adding deployment test results to wallpaper using BGInfo"
+Write-Header 'Adding deployment test results to wallpaper using BGInfo'
 
 Set-Content "$Env:windir\TEMP\hcibox-tests-succeeded.txt" $tests_passed
 Set-Content "$Env:windir\TEMP\hcibox-tests-failed.txt" $tests_failed
@@ -129,18 +143,18 @@ Set-Content "$Env:windir\TEMP\hcibox-tests-failed.txt" $tests_failed
 bginfo.exe $Env:HCIBoxTestsDir\hcibox-bginfo.bgi /timer:0 /NOLICPROMPT
 
 # Setup scheduled task for running tests on each logon
-$TaskName = "Pester tests"
-$ActionScript = "C:\HCIBox\Tests\Invoke-Test.ps1"
+$TaskName = 'Pester tests'
+$ActionScript = 'C:\HCIBox\Tests\Invoke-Test.ps1'
 
 # Check if the scheduled task exists
-if (Get-ScheduledTask | Where-Object {$_.TaskName -eq $TaskName}) {
+if (Get-ScheduledTask | Where-Object { $_.TaskName -eq $TaskName }) {
     Write-Host "Scheduled task '$TaskName' already exists."
 } else {
     # Create the task trigger
     $Trigger = New-ScheduledTaskTrigger -AtLogOn
 
     # Create the task action to use pwsh.exe
-    $Action = New-ScheduledTaskAction -Execute "pwsh.exe" -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File $ActionScript"
+    $Action = New-ScheduledTaskAction -Execute 'pwsh.exe' -Argument "-ExecutionPolicy Bypass -WindowStyle Hidden -File $ActionScript"
 
     $UserName = $Env:UserName
 

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/tests/hci.tests.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/tests/hci.tests.ps1
@@ -14,22 +14,24 @@ BeforeDiscovery {
 
 }
 
-Describe "<cluster>" -ForEach $clusters {
-    BeforeAll {
-        $cluster = $_
-        $clusterObject = Get-AzStackHciCluster -ResourceGroupName $env:resourceGroup -Name $cluster
+if ("True" -eq $env:autoDeployClusterResource) {
+    Describe "<cluster>" -ForEach $clusters {
+        BeforeAll {
+            $cluster = $_
+            $clusterObject = Get-AzStackHciCluster -ResourceGroupName $env:resourceGroup -Name $cluster
+        }
+        It "Cluster exists" {
+            $clusterObject | Should -Not -BeNullOrEmpty
+        }
+        It "Azure Arc Connected cluster is successfully provisioned" {
+            $clusterObject.ProvisioningState | Should -Be "Succeeded"
+        }
+        It "Azure Arc Connected cluster is connected" {
+            $clusterObject.ConnectivityStatus | Should -Be "Connected"
+        }
     }
-    It "Cluster exists" {
-        $clusterObject | Should -Not -BeNullOrEmpty
-    }
-    It "Azure Arc Connected cluster is successfully provisioned" {
-        $clusterObject.ProvisioningState | Should -Be "Succeeded"
-    }
-    It "Azure Arc Connected cluster is connected" {
-        $clusterObject.ConnectivityStatus | Should -Be "Connected"
-    }
-}
 
+}
 
 Describe "<vm>" -ForEach $VMs {
     BeforeAll {

--- a/azure_jumpstart_hcibox/bicep/host/host.bicep
+++ b/azure_jumpstart_hcibox/bicep/host/host.bicep
@@ -19,9 +19,7 @@ param location string = resourceGroup().location
 @description('Resource Id of the subnet in the virtual network')
 param subnetId string
 
-param resourceTags object = {
-  Project: 'jumpstart_HCIBox'
-}
+param resourceTags object
 
 @description('Client id of the service principal')
 param spnClientId string
@@ -98,6 +96,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2021-03-01' = {
       }
     ]
   }
+  tags: resourceTags
 }
 
 resource publicIpAddress 'Microsoft.Network/publicIpAddresses@2021-03-01' = if (deployBastion == false) {
@@ -111,6 +110,7 @@ resource publicIpAddress 'Microsoft.Network/publicIpAddresses@2021-03-01' = if (
   sku: {
     name: 'Basic'
   }
+  tags: resourceTags
 }
 
 resource vm 'Microsoft.Compute/virtualMachines@2022-03-01' = {

--- a/azure_jumpstart_hcibox/bicep/main.bicep
+++ b/azure_jumpstart_hcibox/bicep/main.bicep
@@ -50,6 +50,12 @@ param autoUpgradeClusterResource bool = false
 @description('Enable automatic logon into HCIBox Virtual Machine')
 param vmAutologon bool = true
 
+param resourceTags object = {
+  Project: 'jumpstart_HCIBox'
+  CostControl: 'Ignore'
+  SecurityControl: 'Ignore'
+}
+
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_hcibox/'
 
 module mgmtArtifactsAndPolicyDeployment 'mgmt/mgmtArtifacts.bicep' = {
@@ -57,6 +63,7 @@ module mgmtArtifactsAndPolicyDeployment 'mgmt/mgmtArtifacts.bicep' = {
   params: {
     workspaceName: logAnalyticsWorkspaceName
     location: location
+    resourceTags: resourceTags
   }
 }
 
@@ -65,6 +72,7 @@ module networkDeployment 'network/network.bicep' = {
   params: {
     deployBastion: deployBastion
     location: location
+    resourceTags: resourceTags
   }
 }
 
@@ -72,6 +80,7 @@ module storageAccountDeployment 'mgmt/storageAccount.bicep' = {
   name: 'stagingStorageAccountDeployment'
   params: {
     location: location
+    resourceTags: resourceTags
   }
 }
 
@@ -95,5 +104,6 @@ module hostDeployment 'host/host.bicep' = {
     autoDeployClusterResource: autoDeployClusterResource
     autoUpgradeClusterResource: autoUpgradeClusterResource
     vmAutologon: vmAutologon
+    resourceTags: resourceTags
   }
 }

--- a/azure_jumpstart_hcibox/bicep/main.bicep
+++ b/azure_jumpstart_hcibox/bicep/main.bicep
@@ -50,11 +50,20 @@ param autoUpgradeClusterResource bool = false
 @description('Enable automatic logon into HCIBox Virtual Machine')
 param vmAutologon bool = true
 
-param resourceTags object = {
+@description('Setting this parameter to `true` will add the `CostControl` and `SecurityControl` tags to the provisioned resources. These tags are applicable to ONLY Microsoft-internal Azure lab tenants and designed for managing automated governance processes related to cost optimization and security controls')
+param governResourceTags bool = true
+
+@description('Tags to be added to all resources')
+
+param tags object = {
   Project: 'jumpstart_HCIBox'
-  CostControl: 'Ignore'
-  SecurityControl: 'Ignore'
 }
+
+// if governResourceTags is true, add the following tags
+var resourceTags = governResourceTags ? union(tags, {
+    CostControl: 'Ignore'
+    SecurityControl: 'Ignore'
+}) : tags
 
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_hcibox/'
 

--- a/azure_jumpstart_hcibox/bicep/main.bicep
+++ b/azure_jumpstart_hcibox/bicep/main.bicep
@@ -42,7 +42,7 @@ param location string = resourceGroup().location
 param rdpPort string = '3389'
 
 @description('Choice to enable automatic deployment of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Default is false.')
-param autoDeployClusterResource bool = false
+param autoDeployClusterResource bool = true
 
 @description('Choice to enable automatic upgrade of Azure Arc enabled HCI cluster resource after the client VM deployment is complete. Only applicable when autoDeployClusterResource is true. Default is false.')
 param autoUpgradeClusterResource bool = false

--- a/azure_jumpstart_hcibox/bicep/mgmt/mgmtArtifacts.bicep
+++ b/azure_jumpstart_hcibox/bicep/mgmt/mgmtArtifacts.bicep
@@ -7,10 +7,7 @@ param location string = resourceGroup().location
 @description('SKU, leave default pergb2018')
 param sku string = 'pergb2018'
 
-var security = {
-  name: 'Security(${workspaceName})'
-  galleryName: 'Security'
-}
+param resourceTags object
 
 var automationAccountName = 'HCIBox-Automation-${uniqueString(resourceGroup().id)}'
 var automationAccountLocation = ((location == 'eastus') ? 'eastus2' : ((location == 'eastus2') ? 'eastus' : location))
@@ -23,34 +20,7 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' = {
       name: sku
     }
   }
-}
-
-resource VMInsightsMicrosoftOperationalInsights 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
-  location: location
-  name: 'VMInsights(${split(workspace.id, '/')[8]})'
-  properties: {
-    workspaceResourceId: workspace.id
-  }
-  plan: {
-    name: 'VMInsights(${split(workspace.id, '/')[8]})'
-    product: 'OMSGallery/VMInsights'
-    promotionCode: ''
-    publisher: 'Microsoft'
-  }
-}
-
-resource securityGallery 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
-  name: security.name
-  location: location
-  properties: {
-    workspaceResourceId: workspace.id
-  }
-  plan: {
-    name: security.name
-    promotionCode: ''
-    product: 'OMSGallery/${security.galleryName}'
-    publisher: 'Microsoft'
-  }
+  tags: resourceTags
 }
 
 resource automationAccount 'Microsoft.Automation/automationAccounts@2021-06-22' = {
@@ -64,12 +34,5 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2021-06-22' 
   dependsOn: [
     workspace
   ]
-}
-
-resource workspaceAutomation 'Microsoft.OperationalInsights/workspaces/linkedServices@2020-08-01' = {
-  parent: workspace
-  name: 'Automation'
-  properties: {
-    resourceId: automationAccount.id
-  }
+  tags: resourceTags
 }

--- a/azure_jumpstart_hcibox/bicep/mgmt/storageAccount.bicep
+++ b/azure_jumpstart_hcibox/bicep/mgmt/storageAccount.bicep
@@ -10,6 +10,8 @@ param storageAccountType string = 'Standard_LRS'
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
+param resourceTags object
+
 var storageAccountName = 'hcibox${uniqueString(resourceGroup().id)}'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
@@ -22,6 +24,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-06-01' = {
   properties: {
     supportsHttpsTrafficOnly: true
   }
+  tags: resourceTags
 }
 
 output storageAccountName string = storageAccountName

--- a/azure_jumpstart_hcibox/bicep/network/network.bicep
+++ b/azure_jumpstart_hcibox/bicep/network/network.bicep
@@ -16,6 +16,8 @@ param networkSecurityGroupName string = 'HCIBox-NSG'
 @description('Name of the Bastion Network Security Group')
 param bastionNetworkSecurityGroupName string = 'HCIBox-Bastion-NSG'
 
+param resourceTags object
+
 var addressPrefix = '172.16.0.0/16'
 var subnetAddressPrefix = '172.16.1.0/24'
 var bastionSubnetName = 'AzureBastionSubnet'
@@ -68,6 +70,7 @@ resource arcVirtualNetwork 'Microsoft.Network/virtualNetworks@2021-03-01' = {
       }
     ]
   }
+ tags: resourceTags
 }
 
 resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-03-01' = {
@@ -75,9 +78,10 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-03-0
   location: location
   properties: {
     securityRules: [
-      
+
     ]
   }
+  tags: resourceTags
 }
 
 resource bastionNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-05-01' = if (deployBastion == true) {
@@ -203,6 +207,7 @@ resource bastionNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@20
       }
     ]
   }
+  tags: resourceTags
 }
 
 resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' = if (deployBastion == true) {
@@ -216,6 +221,7 @@ resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' = if (
   sku: {
     name: 'Standard'
   }
+  tags: resourceTags
 }
 
 resource bastionHost 'Microsoft.Network/bastionHosts@2021-05-01' = if (deployBastion == true) {
@@ -236,6 +242,7 @@ resource bastionHost 'Microsoft.Network/bastionHosts@2021-05-01' = if (deployBas
       }
     ]
   }
+  tags: resourceTags
 }
 
 output vnetId string = arcVirtualNetwork.id


### PR DESCRIPTION
This pull request includes updates to the `azure_jumpstart_hcibox` project, focusing on adding governance tags to resources and improving the automation of cluster deployment. The changes span across multiple files, including PowerShell scripts and Bicep templates.

Key changes include:

### Governance Tags Addition:
* [`azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1`](diffhunk://#diff-5b4847618a370128843e9a81cbad82e72918bddbe3471fbf0f62859a2aaf629fR1913-R1937): Added known governance tags (`CostControl`, `SecurityControl`) to resources like Key Vaults, Storage Accounts, and Disks to avoid disruptions during deployment.

### Bicep Template Updates:
* [`azure_jumpstart_hcibox/bicep/host/host.bicep`](diffhunk://#diff-88413a633c596449c8ebcf0ed64bc7321f5e6ee2fc8f94a0cee2bb04a64c0dafL22-R22): Removed default values for `resourceTags` and added tags to network interfaces and public IP addresses. [[1]](diffhunk://#diff-88413a633c596449c8ebcf0ed64bc7321f5e6ee2fc8f94a0cee2bb04a64c0dafL22-R22) [[2]](diffhunk://#diff-88413a633c596449c8ebcf0ed64bc7321f5e6ee2fc8f94a0cee2bb04a64c0dafR99) [[3]](diffhunk://#diff-88413a633c596449c8ebcf0ed64bc7321f5e6ee2fc8f94a0cee2bb04a64c0dafR113)
* [`azure_jumpstart_hcibox/bicep/main.bicep`](diffhunk://#diff-5056bf2cb0a281ffbb429576cde9ef2848784706ecd753a4b398cd9db301a1d6R53-R66): Added `resourceTags` parameter and propagated it to various modules, including network and storage account deployments. [[1]](diffhunk://#diff-5056bf2cb0a281ffbb429576cde9ef2848784706ecd753a4b398cd9db301a1d6R53-R66) [[2]](diffhunk://#diff-5056bf2cb0a281ffbb429576cde9ef2848784706ecd753a4b398cd9db301a1d6R75-R83) [[3]](diffhunk://#diff-5056bf2cb0a281ffbb429576cde9ef2848784706ecd753a4b398cd9db301a1d6R107)
* [`azure_jumpstart_hcibox/bicep/mgmt/mgmtArtifacts.bicep`](diffhunk://#diff-bddf0f8d60c4e2d4a0f6df83f5175477fa6127701f111acc7174870ce9fe2276L10-R10): Introduced `resourceTags` parameter and applied tags to resources like the automation account. Removed unnecessary VM insights and security gallery resources. [[1]](diffhunk://#diff-bddf0f8d60c4e2d4a0f6df83f5175477fa6127701f111acc7174870ce9fe2276L10-R10) [[2]](diffhunk://#diff-bddf0f8d60c4e2d4a0f6df83f5175477fa6127701f111acc7174870ce9fe2276L26-R23) [[3]](diffhunk://#diff-bddf0f8d60c4e2d4a0f6df83f5175477fa6127701f111acc7174870ce9fe2276L67-R37)
* [`azure_jumpstart_hcibox/bicep/mgmt/storageAccount.bicep`](diffhunk://#diff-fcee9ff3f5628ee6c1f81cb034bd95c0fe41d300404b6daac0caddbb0eb1948eR13-R14): Added `resourceTags` parameter and applied tags to the storage account resource. [[1]](diffhunk://#diff-fcee9ff3f5628ee6c1f81cb034bd95c0fe41d300404b6daac0caddbb0eb1948eR13-R14) [[2]](diffhunk://#diff-fcee9ff3f5628ee6c1f81cb034bd95c0fe41d300404b6daac0caddbb0eb1948eR27)
* [`azure_jumpstart_hcibox/bicep/network/network.bicep`](diffhunk://#diff-73920a79fc51eace9329a71c8dd14da12efed94dddc5d5ec64ef1dd9f4ebaf22R19-R20): Added `resourceTags` parameter and applied tags to various network resources, including virtual networks and network security groups. [[1]](diffhunk://#diff-73920a79fc51eace9329a71c8dd14da12efed94dddc5d5ec64ef1dd9f4ebaf22R19-R20) [[2]](diffhunk://#diff-73920a79fc51eace9329a71c8dd14da12efed94dddc5d5ec64ef1dd9f4ebaf22R73) [[3]](diffhunk://#diff-73920a79fc51eace9329a71c8dd14da12efed94dddc5d5ec64ef1dd9f4ebaf22R84) [[4]](diffhunk://#diff-73920a79fc51eace9329a71c8dd14da12efed94dddc5d5ec64ef1dd9f4ebaf22R210) [[5]](diffhunk://#diff-73920a79fc51eace9329a71c8dd14da12efed94dddc5d5ec64ef1dd9f4ebaf22R224) [[6]](diffhunk://#diff-73920a79fc51eace9329a71c8dd14da12efed94dddc5d5ec64ef1dd9f4ebaf22R245)

### Automation Enhancements:
* [`azure_jumpstart_hcibox/artifacts/PowerShell/tests/Invoke-Test.ps1`](diffhunk://#diff-d8052766bd960eb8d583b8ea7864dce351f55814dc2f59b53d98af563b487019R76-R85): Wrapped deployment and connectivity checks in a conditional block triggered by the `autoDeployClusterResource` environment variable.
* [`azure_jumpstart_hcibox/artifacts/PowerShell/tests/hci.tests.ps1`](diffhunk://#diff-b68eb41b3eb111321e82f5b33936d2e68d294c78534e9e0e2eff7bc13ad69519R17): Added conditional blocks around test descriptions to support the `autoDeployClusterResource` environment variable. [[1]](diffhunk://#diff-b68eb41b3eb111321e82f5b33936d2e68d294c78534e9e0e2eff7bc13ad69519R17) [[2]](diffhunk://#diff-b68eb41b3eb111321e82f5b33936d2e68d294c78534e9e0e2eff7bc13ad69519R34)

- Fixes #2998 
- Fixes #3002 