### PR TITLE
Workaround for issue 3035 - RDP hang

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -392,6 +392,22 @@ if (($rdpPort -ne $null) -and ($rdpPort -ne "") -and ($rdpPort -ne "3389")) {
     Write-Host "RDP port configuration complete."
 }
 
+# Workaround for https://github.com/microsoft/azure_arc/issues/3035
+
+# Define firewall rule name
+$ruleName = "Block RDP UDP 3389"
+
+# Check if the rule already exists
+$existingRule = Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue
+
+if ($existingRule) {
+    Write-Host "Firewall rule '$ruleName' already exists. No changes made."
+} else {
+    # Create a new firewall rule to block UDP traffic on port 3389
+    New-NetFirewallRule -DisplayName $ruleName -Direction Inbound -Protocol UDP -LocalPort 3389 -Action Block -Enabled True
+    Write-Host "Firewall rule '$ruleName' created successfully. RDP UDP is now blocked."
+}
+
 Write-Header "Configuring Logon Scripts"
 
 $ScheduledTaskExecutable = "pwsh.exe"

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -408,6 +408,26 @@ if ($existingRule) {
     Write-Host "Firewall rule '$ruleName' created successfully. RDP UDP is now blocked."
 }
 
+# Define the registry path
+$registryPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services"
+
+# Define the registry key name
+$registryName = "fClientDisableUDP"
+
+# Define the value (1 = Disable Connect Time Detect and Continuous Network Detect)
+$registryValue = 1
+
+# Check if the registry path exists, if not, create it
+if (-not (Test-Path $registryPath)) {
+    New-Item -Path $registryPath -Force | Out-Null
+}
+
+# Set the registry key
+Set-ItemProperty -Path $registryPath -Name $registryName -Value $registryValue -Type DWord
+
+# Confirm the change
+Write-Host "Registry setting applied successfully. fClientDisableUDP set to $registryValue"
+
 Write-Header "Configuring Logon Scripts"
 
 $ScheduledTaskExecutable = "pwsh.exe"

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
@@ -289,6 +289,22 @@ if (($rdpPort -ne $null) -and ($rdpPort -ne "") -and ($rdpPort -ne "3389")) {
   Write-Host "RDP port configuration complete."
 }
 
+# Workaround for https://github.com/microsoft/azure_arc/issues/3035
+
+# Define firewall rule name
+$ruleName = "Block RDP UDP 3389"
+
+# Check if the rule already exists
+$existingRule = Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue
+
+if ($existingRule) {
+    Write-Host "Firewall rule '$ruleName' already exists. No changes made."
+} else {
+    # Create a new firewall rule to block UDP traffic on port 3389
+    New-NetFirewallRule -DisplayName $ruleName -Direction Inbound -Protocol UDP -LocalPort 3389 -Action Block -Enabled True
+    Write-Host "Firewall rule '$ruleName' created successfully. RDP UDP is now blocked."
+}
+
 # Install Hyper-V and reboot
 Write-Header "Installing Hyper-V."
 Enable-WindowsOptionalFeature -Online -FeatureName Containers -All -NoRestart

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1
@@ -305,6 +305,26 @@ if ($existingRule) {
     Write-Host "Firewall rule '$ruleName' created successfully. RDP UDP is now blocked."
 }
 
+# Define the registry path
+$registryPath = "HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services"
+
+# Define the registry key name
+$registryName = "fClientDisableUDP"
+
+# Define the value (1 = Disable Connect Time Detect and Continuous Network Detect)
+$registryValue = 1
+
+# Check if the registry path exists, if not, create it
+if (-not (Test-Path $registryPath)) {
+    New-Item -Path $registryPath -Force | Out-Null
+}
+
+# Set the registry key
+Set-ItemProperty -Path $registryPath -Name $registryName -Value $registryValue -Type DWord
+
+# Confirm the change
+Write-Host "Registry setting applied successfully. fClientDisableUDP set to $registryValue"
+
 # Install Hyper-V and reboot
 Write-Header "Installing Hyper-V."
 Enable-WindowsOptionalFeature -Online -FeatureName Containers -All -NoRestart

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/Generate-ARM-Template.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/Generate-ARM-Template.ps1
@@ -15,7 +15,7 @@ Start-Transcript -Path "$($HCIBoxConfig.Paths.LogsDir)\Generate-ARM-Template.log
 # $ErrorActionPreference = "Stop"
 
 $arcNodes = Get-AzConnectedMachine -ResourceGroup $env:resourceGroup
-$arcNodeResourceIds = $arcNodes.Id | ConvertTo-Json
+$arcNodeResourceIds = $arcNodes.Id | ConvertTo-Json -AsArray
 
 # foreach ($machine in $arcNodes) {
 #     $ErrorActionPreference = "Continue"

--- a/azure_jumpstart_hcibox/artifacts/PowerShell/tests/common.tests.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/tests/common.tests.ps1
@@ -8,7 +8,7 @@ Describe "ArcBox resource group" {
     BeforeAll {
         $ResourceGroupName = $env:resourceGroup
     }
-    It "should have 30 resources or more" {
-        (Get-AzResource -ResourceGroupName $ResourceGroupName).count | Should -BeGreaterOrEqual 30
+    It "should have 25 resources or more" {
+        (Get-AzResource -ResourceGroupName $ResourceGroupName).count | Should -BeGreaterOrEqual 25
     }
 }


### PR DESCRIPTION
This pull request includes several updates to the `azure_jumpstart_arcbox` and `azure_jumpstart_hcibox` projects. The changes primarily focus on adding a workaround for a known issue, updating a test expectation, and modifying a JSON conversion.

Fixes #3035 

* [`azure_jumpstart_arcbox/artifacts/Bootstrap.ps1`](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R395-R410): Added a firewall rule to block UDP traffic on port 3389 to address a known issue.
* [`azure_jumpstart_hcibox/artifacts/PowerShell/Bootstrap.ps1`](diffhunk://#diff-0bedbbf2c2a412589fe06320754e5471c9cd49f1182e7d2734de4ed206c23b19R292-R307): Added a similar firewall rule to block UDP traffic on port 3389 to address the same issue.
