### PR TITLE
Feb ArcData Release

### DIFF
--- a/arc_data_services/charts/arcdataservices/values.yaml
+++ b/arc_data_services/charts/arcdataservices/values.yaml
@@ -38,7 +38,7 @@ Azure:
     InstallerServiceAccount: ""
     RuntimeServiceAccount: ""
 systemDefaultValues:
-  image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12
+  image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11
   imagePullPolicy: Always
   imagePullSecret: arc-private-registry
   installerServiceAccount: ""

--- a/arc_data_services/deploy/scripts/pull-and-push-arc-data-services-images-to-private-registry.py
+++ b/arc_data_services/deploy/scripts/pull-and-push-arc-data-services-images-to-private-registry.py
@@ -54,9 +54,9 @@ else:
 if os.getenv("SOURCE_DOCKER_TAG") is None:
     SOURCE_DOCKER_TAG = (
         input(
-            "Provide container image tag for the images at the source - press ENTER for using 'v1.35.0_2024-11-12': "
+            "Provide container image tag for the images at the source - press ENTER for using 'v1.36.0_2025-02-11': "
         )
-        or "v1.35.0_2024-11-12"
+        or "v1.36.0_2025-02-11"
     )
 else:
     SOURCE_DOCKER_TAG = os.environ["SOURCE_DOCKER_TAG"]

--- a/arc_data_services/deploy/yaml/bootstrapper-unified.yaml
+++ b/arc_data_services/deploy/yaml/bootstrapper-unified.yaml
@@ -331,11 +331,11 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: bootstrapper
-        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12
+        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11
         imagePullPolicy: Always
         args:
         - -image
-        - mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12
+        - mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11
         - -policy
         - Always
         - -chart

--- a/arc_data_services/deploy/yaml/bootstrapper.yaml
+++ b/arc_data_services/deploy/yaml/bootstrapper.yaml
@@ -9,11 +9,11 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: bootstrapper
-        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12
+        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11
         imagePullPolicy: Always
         args:
         - -image
-        - mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12
+        - mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11
         - -policy
         - Always
         - -chart

--- a/arc_data_services/deploy/yaml/data-controller.yaml
+++ b/arc_data_services/deploy/yaml/data-controller.yaml
@@ -30,7 +30,7 @@ spec:
     serviceAccount: sa-arc-controller
   docker:
     imagePullPolicy: Always
-    imageTag: v1.35.0_2024-11-12
+    imageTag: v1.36.0_2025-02-11
     registry: mcr.microsoft.com
     repository: arcdata
   infrastructure: other # Must be a value in the array [alibaba, aws, azure, gcp, onpremises, other]

--- a/arc_data_services/deploy/yaml/uninstall.yaml
+++ b/arc_data_services/deploy/yaml/uninstall.yaml
@@ -9,7 +9,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: bootstrapper
-        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12
+        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11
         imagePullPolicy: IfNotPresent
         args: ["-uninstall"]
         command: ["/opt/bootstrapper/bin/bootstrapper"]

--- a/arc_data_services/test/launcher/base/kustomization.yaml
+++ b/arc_data_services/test/launcher/base/kustomization.yaml
@@ -10,4 +10,4 @@ secretGenerator:
 images:
 - name: arc-ci-launcher
   newName: mcr.microsoft.com/arcdata/arc-ci-launcher
-  newTag: v1.35.0_2024-11-12
+  newTag: v1.36.0_2025-02-11

--- a/arc_data_services/upgrade/yaml/bootstrapper-upgrade-job.yaml
+++ b/arc_data_services/upgrade/yaml/bootstrapper-upgrade-job.yaml
@@ -11,10 +11,10 @@ spec:
       - name: your-private-registry
       containers:
       - name: bootstrapper
-        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12
+        image: mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11
         imagePullPolicy: Always
         command: ["/opt/bootstrapper/bin/bootstrapper"]
-        args: ["-image", "mcr.microsoft.com/arcdata/arc-bootstrapper:v1.35.0_2024-11-12", "-policy", "Always", "-chart", "/opt/helm/arcdataservices", "-bootstrap"]
+        args: ["-image", "mcr.microsoft.com/arcdata/arc-bootstrapper:v1.36.0_2025-02-11", "-policy", "Always", "-chart", "/opt/helm/arcdataservices", "-bootstrap"]
         resources:
           limits:
             cpu: 200m

--- a/arc_data_services/upgrade/yaml/data-controller-upgrade.yaml
+++ b/arc_data_services/upgrade/yaml/data-controller-upgrade.yaml
@@ -4,5 +4,5 @@ metadata:
   name: arc
 spec:
   docker:
-    imageTag: v1.35.0_2024-11-12
+    imageTag: v1.36.0_2025-02-11
     

--- a/arc_data_services/upgrade/yaml/request_body/request-body-after.yaml
+++ b/arc_data_services/upgrade/yaml/request_body/request-body-after.yaml
@@ -27,7 +27,7 @@
         },
         "docker": {
           "imagePullPolicy": "Always",
-          "imageTag": "v1.35.0_2024-11-12",
+          "imageTag": "v1.36.0_2025-02-11",
           "registry": "<registry>",
           "repository": "<repository>"
         },

--- a/arc_data_services/upgrade/yaml/request_body/request-body-before.yaml
+++ b/arc_data_services/upgrade/yaml/request_body/request-body-before.yaml
@@ -25,7 +25,7 @@
         },
         "docker": {
           "imagePullPolicy": "Always",
-          "imageTag": "v1.35.0_2024-11-12",
+          "imageTag": "v1.36.0_2025-02-11",
           "registry": "<registry>",
           "repository": "<repository>"
         },

--- a/archive/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/archive/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/DataServicesLogonScript.ps1
@@ -146,7 +146,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $Env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper
 

--- a/archive/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
+++ b/archive/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1
@@ -112,7 +112,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $Env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper `
 

--- a/azure_arc_data_jumpstart/aks/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/ARM/artifacts/DataServicesLogonScript.ps1
@@ -130,7 +130,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $Env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper
 

--- a/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/DR/ARM/artifacts/DataServicesLogonScript.ps1
@@ -135,7 +135,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $Env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper `
 
@@ -229,7 +229,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $Env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper `
 

--- a/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/DataServicesLogonScript.ps1
@@ -224,7 +224,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $Env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper `
 

--- a/azure_arc_data_jumpstart/eks/terraform/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/eks/terraform/artifacts/DataServicesLogonScript.ps1
@@ -134,7 +134,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $Env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper
 

--- a/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
+++ b/azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1
@@ -123,7 +123,7 @@ az k8s-extension create --name arc-data-services `
                         --resource-group $env:resourceGroup `
                         --auto-upgrade false `
                         --scope cluster `
-                        --version 1.35.0 `
+                        --version 1.36.0 `
                         --release-namespace arc `
                         --config Microsoft.CustomLocation.ServiceAccount=sa-arc-bootstrapper `
 

--- a/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1
@@ -398,7 +398,7 @@ $clusters | Foreach-Object {
             --auto-upgrade false `
             --scope cluster `
             --release-namespace arc `
-            --version 1.35.0 `
+            --version 1.36.0 `
             --config Microsoft.CustomLocation.ServiceAccount=sa-bootstrapper
 
             Write-Host "`n"


### PR DESCRIPTION
This pull request includes several updates to the version of the `arc-bootstrapper` image and related tags across multiple files in the `arc_data_services` directory. The changes ensure that the system uses the latest version of the image, `v1.36.0_2025-02-11`.

### Updates to image versions:

* [`arc_data_services/charts/arcdataservices/values.yaml`](diffhunk://#diff-833528ae7b30a8961daa5ae8acfb7b1e03461b59a325c0c86f4e7b0eafe62538L41-R41): Updated the `systemDefaultValues` image to `v1.36.0_2025-02-11`.
* [`arc_data_services/deploy/scripts/pull-and-push-arc-data-services-images-to-private-registry.py`](diffhunk://#diff-a51ff7b9c90529ced139af1358fb972b321a63e64bb59106aa1c3c1099dac034L57-R59): Changed the default container image tag prompt to `v1.36.0_2025-02-11`.
* [`arc_data_services/deploy/yaml/bootstrapper-unified.yaml`](diffhunk://#diff-1a83bf7b009367c572fa5cab61eade95b3cf9cfe6bb8b6d3f20a0764f6ddce84L334-R338): Updated the bootstrapper container image and arguments to use `v1.36.0_2025-02-11`.
* [`arc_data_services/deploy/yaml/bootstrapper.yaml`](diffhunk://#diff-9b0a22dc1dc4a26dd5ef8e22e82433403333965fabcd59d710c3feb5254b2eacL12-R16): Updated the bootstrapper container image and arguments to use `v1.36.0_2025-02-11`.
* [`arc_data_services/deploy/yaml/data-controller.yaml`](diffhunk://#diff-16ce8f479b2aa0c17557f5a805460f7c939b07615c236e5e1ec24cce59e72271L33-R33): Updated the `imageTag` to `v1.36.0_2025-02-11`.

### Updates to related scripts and configurations:

* [`arc_data_services/deploy/yaml/uninstall.yaml`](diffhunk://#diff-ae5bde82ebffec8d0420737b52abf734bef3fc5a2a55dacf04b0cb915d4fa1bfL12-R12): Updated the bootstrapper container image to `v1.36.0_2025-02-11`.
* [`arc_data_services/test/launcher/base/kustomization.yaml`](diffhunk://#diff-0bb51dd2797996cf30bca310d9f262def87805ecd2f84d7304660cbca9943c94L13-R13): Updated the `arc-ci-launcher` image tag to `v1.36.0_2025-02-11`.
* [`arc_data_services/upgrade/yaml/bootstrapper-upgrade-job.yaml`](diffhunk://#diff-3e73cfd25512859eed8db2342f47d69cc5fb9e8e6e395ccec5bdf040eb3b3a58L14-R17): Updated the bootstrapper container image and arguments to use `v1.36.0_2025-02-11`.
* [`arc_data_services/upgrade/yaml/data-controller-upgrade.yaml`](diffhunk://#diff-1efbce068db61e27cccbc57bf3db989aab0e4dbad3602ed08b736b5867c84321L7-R7): Updated the `imageTag` to `v1.36.0_2025-02-11`.
* [`arc_data_services/upgrade/yaml/request_body/request-body-after.yaml`](diffhunk://#diff-e1bb7c36564c99115c1aa65869b855f03717f6716acf0855202f205e95ae569aL30-R30): Updated the `imageTag` to `v1.36.0_2025-02-11`.
* [`arc_data_services/upgrade/yaml/request_body/request-body-before.yaml`](diffhunk://#diff-dbec888f9c42fb570dfc2415a96618bcb468f5a464a33a2d14487b704f84efe9L28-R28): Updated the `imageTag` to `v1.36.0_2025-02-11`.

### Updates to Azure Arc Data Jumpstart scripts:

* [`archive/azure_arc_data_jumpstart/kubeadm/azure/ARM/artifacts/DataServicesLogonScript.ps1`](diffhunk://#diff-dd19eb4caba376eb037358552e09a71a4e1af4a48feb766ddc3fec2780aee1bcL149-R149): Updated the `az k8s-extension` version to `1.36.0`.
* [`archive/azure_arc_data_jumpstart/microk8s/azure/arm_template/artifacts/DataServicesLogonScript.ps1`](diffhunk://#diff-85db6315abef293de050c0e21f936883325f6a39f24d5eb9ef42d48c3382a507L115-R115): Updated the `az k8s-extension` version to `1.36.0`.
* [`azure_arc_data_jumpstart/aks/ARM/artifacts/DataServicesLogonScript.ps1`](diffhunk://#diff-cdd6d1d906e4d9273ba08d779293d977083701c35a7453441210d9072d10db28L133-R133): Updated the `az k8s-extension` version to `1.36.0`.
* [`azure_arc_data_jumpstart/aks/DR/ARM/artifacts/DataServicesLogonScript.ps1`](diffhunk://#diff-719b6e6f33c96aec4961ab0e69a37331dc3de0d64f38f6fdde2e30fc7d5441f0L138-R138): Updated the `az k8s-extension` version to `1.36.0`. [[1]](diffhunk://#diff-719b6e6f33c96aec4961ab0e69a37331dc3de0d64f38f6fdde2e30fc7d5441f0L138-R138) [[2]](diffhunk://#diff-719b6e6f33c96aec4961ab0e69a37331dc3de0d64f38f6fdde2e30fc7d5441f0L232-R232)
* [`azure_arc_data_jumpstart/aks/Migration/ARM/artifacts/DataServicesLogonScript.ps1`](diffhunk://#diff-ffa802ad00488b1304dadee65e58e83e176090d3e7f2c830c3db68b6a7afc499L227-R227): Updated the `az k8s-extension` version to `1.36.0`.
* [`azure_arc_data_jumpstart/eks/terraform/artifacts/DataServicesLogonScript.ps1`](diffhunk://#diff-9fa3cdfc2831cda2b3aa8af799726692b49880270933e58ca7d7cff3a718d628L137-R137): Updated the `az k8s-extension` version to `1.36.0`.
* [`azure_arc_data_jumpstart/gke/terraform/artifacts/DataServicesLogonScript.ps1`](diffhunk://#diff-b27e5e00fd45e501223fe49e0d3c9d26b3e66a5536d2c659f7e6808390ee20f2L126-R126): Updated the `az k8s-extension` version to `1.36.0`.
* [`azure_jumpstart_arcbox/artifacts/DataOpsLogonScript.ps1`](diffhunk://#diff-80a8bdccfba3949adc618a35b651273164d5b3e0994713cadf5ebb37033d4b32L401-R401): Updated the `az k8s-extension` version to `1.36.0`.