### PR TITLE
Add workaround for Azure Edge Lifecycle Manager extension deployment

### DIFF
--- a/azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1
+++ b/azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1
@@ -1577,6 +1577,22 @@ function Set-HCIDeployPrereqs {
 
 }
 
+function Set-HCIDeployPrereqsWorkaround {
+
+    Get-AzConnectedMachine -ResourceGroupName $env:resourceGroup | ForEach-Object {
+
+        Remove-AzConnectedMachineExtension -MachineName $PSItem.Name -ResourceGroupName $env:resourceGroup -Name AzureEdgeLifecycleManager -AsJob
+
+    } | Wait-Job
+
+
+       Get-AzConnectedMachine -ResourceGroupName $env:resourceGroup | ForEach-Object {
+
+        New-AzConnectedMachineExtension -MachineName $PSItem.Name -ResourceGroupName $env:resourceGroup -Name AzureEdgeLifecycleManager -AsJob -TypeHandlerVersion 30.2411.2.789 -Location $env:azureLocation -Publisher "Microsoft.AzureStack.Orchestration" -ExtensionType "LcmController"
+
+    } | Wait-Job
+
+}
 function Update-HCICluster {
     param (
         $HCIBoxConfig,
@@ -1876,6 +1892,8 @@ $null = Set-AzResourceGroup -ResourceGroupName $env:resourceGroup -Tag $tags
 $null = Set-AzResource -ResourceName $env:computername -ResourceGroupName $env:resourceGroup -ResourceType 'microsoft.compute/virtualmachines' -Tag $tags -Force
 
 Set-HCIDeployPrereqs -HCIBoxConfig $HCIBoxConfig -localCred $localCred -domainCred $domainCred
+
+Set-HCIDeployPrereqsWorkaround
 
 & "$Env:HCIBoxDir\Generate-ARM-Template.ps1"
 


### PR DESCRIPTION
This pull request includes changes to the `azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1` script to address deployment prerequisites and update the HCI cluster setup process. The most important changes include the addition of a new function to handle Azure connected machine extensions and the invocation of this new function in the deployment process.

Deployment prerequisites updates:

* [`azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1`](diffhunk://#diff-5b4847618a370128843e9a81cbad82e72918bddbe3471fbf0f62859a2aaf629fR1580-R1595): Added a new function `Set-HCIDeployPrereqsWorkaround` to remove and re-add the `AzureEdgeLifecycleManager` extension for Azure connected machines.

HCI cluster setup process:

* [`azure_jumpstart_hcibox/artifacts/PowerShell/New-HCIBoxCluster.ps1`](diffhunk://#diff-5b4847618a370128843e9a81cbad82e72918bddbe3471fbf0f62859a2aaf629fR1896-R1897): Modified the script to call the newly added `Set-HCIDeployPrereqsWorkaround` function after setting the HCI deployment prerequisites.

- Fixes #3133