### PR TITLE
ArcBox - Enhancements to VM shutdown settings

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -486,7 +486,7 @@ if ($Env:flavor -ne 'DevOps') {
         (Get-Content -Path $serversDscConfigurationFile) -replace 'namingPrefixStage', $namingPrefix | Set-Content -Path $serversDscConfigurationFile
         winget configure --file C:\ArcBox\DSC\virtual_machines_itpro.dsc.yml --accept-configuration-agreements --disable-interactivity
 
-    # Avoid issue https://github.com/microsoft/azure_arc/issues/3143
+    # Configure automatic start & stop action for the nested VMs
     Get-VM | Where-Object {$_.State -eq "Running"} |
         ForEach-Object -Parallel {
             Stop-VM -Force -Name $PSItem.Name

--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -486,6 +486,15 @@ if ($Env:flavor -ne 'DevOps') {
         (Get-Content -Path $serversDscConfigurationFile) -replace 'namingPrefixStage', $namingPrefix | Set-Content -Path $serversDscConfigurationFile
         winget configure --file C:\ArcBox\DSC\virtual_machines_itpro.dsc.yml --accept-configuration-agreements --disable-interactivity
 
+    # Avoid issue https://github.com/microsoft/azure_arc/issues/3143
+    Get-VM | Where-Object {$_.State -eq "Running"} |
+        ForEach-Object -Parallel {
+            Stop-VM -Force -Name $PSItem.Name
+            Set-VM -Name $PSItem.Name -AutomaticStopAction ShutDown -AutomaticStartAction Start
+            Start-VM -Name $PSItem.Name
+        }
+    Start-Sleep -Seconds 30
+
         Write-Header 'Creating VM Credentials'
         # Hard-coded username and password for the nested VMs
         $nestedLinuxUsername = 'jumpstart'


### PR DESCRIPTION
This pull request includes a significant change to the `azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1` file to address an issue with virtual machine states. The most important change involves adding a script to manage the state of running VMs to avoid a known issue.

Changes to VM state management:

* [`azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1`](diffhunk://#diff-c75b551d35d0b6890b130f6fc8d551b8bbd245f913765fc590a5e949da509c2bR489-R497): Added a script to stop, configure, and restart running VMs to avoid issue https://github.com/microsoft/azure_arc/issues/3143. This includes stopping each running VM, setting automatic stop and start actions, and then restarting the VMs, followed by a 30-second sleep period.

- Fixes #3143 

Tested successfully:
![image](https://github.com/user-attachments/assets/3ca988c8-ca33-4089-83c4-4e36a86a7625)
