### PR TITLE
Update azuredeploy.parameters.json

### DIFF
--- a/azure_arc_ml_jumpstart/aks/arm_template/azuredeploy.parameters.json
+++ b/azure_arc_ml_jumpstart/aks/arm_template/azuredeploy.parameters.json
@@ -30,7 +30,7 @@
       "value": "https://raw.githubusercontent.com/microsoft/azure_arc/main/azure_arc_ml_jumpstart/aks/arm_template/"
     },
     "kubernetesVersion": {
-      "value": "1.28.5"
+      "value": "1.31.1"
     },
     "dnsPrefix": {
       "value": "arcml"


### PR DESCRIPTION
It needs version which is supported else it is failing 1.28.5 because this version is under Long-Term Support (LTS) and code does not have default Premium Tier enabled.