### PR TITLE
Contoso Supermarket telemetry and K8s version update

### DIFF
--- a/azure_jumpstart_ag/contoso_supermarket/bicep/kubernetes/aks.bicep
+++ b/azure_jumpstart_ag/contoso_supermarket/bicep/kubernetes/aks.bicep
@@ -62,12 +62,12 @@ param osType string = 'Linux'
 var tier  = 'free'
 
 @description('The version of Kubernetes')
-param kubernetesVersion string = '1.28.5'
+param kubernetesVersion string = '1.32'
 
 var serviceCidr_staging = '10.21.64.0/19'
 var dnsServiceIP_staging = '10.21.64.10'
 
-resource aksStaging 'Microsoft.ContainerService/managedClusters@2023-05-02-preview' = {
+resource aksStaging 'Microsoft.ContainerService/managedClusters@2025-02-01' = {
   location: location
   name: aksStagingClusterName
   tags: resourceTags

--- a/azure_jumpstart_ag/contoso_supermarket/bicep/main.bicep
+++ b/azure_jumpstart_ag/contoso_supermarket/bicep/main.bicep
@@ -88,6 +88,14 @@ param scenario string = 'contoso_supermarket'
 
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_ag/'
 
+var customerUsageAttributionDeploymentName = '7d736ea9-23b4-4134-95a1-560ab7196aae'
+
+module customerUsageAttribution 'mgmt/customerUsageAttribution.bicep' = {
+  name: 'pid-${customerUsageAttributionDeploymentName}'
+  params: {
+  }
+}
+
 module mgmtArtifactsAndPolicyDeployment 'mgmt/mgmtArtifacts.bicep' = {
   name: 'mgmtArtifactsAndPolicyDeployment'
   params: {

--- a/azure_jumpstart_ag/contoso_supermarket/bicep/mgmt/customerUsageAttribution.bicep
+++ b/azure_jumpstart_ag/contoso_supermarket/bicep/mgmt/customerUsageAttribution.bicep
@@ -1,0 +1,4 @@
+targetScope = 'resourceGroup'
+
+// This is an empty deployment by design
+// Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution


### PR DESCRIPTION
this PR adds telemetry for Contoso Supermarket deployments and updates the Kubernetes version to 1.32 to ensure we use a currently  supported version.