### PR TITLE
Contoso Motors - define InfluxDB Admin password & comment deployGPUNodes

### DIFF
--- a/azure_jumpstart_ag/contoso_motors/bicep/main.bicep
+++ b/azure_jumpstart_ag/contoso_motors/bicep/main.bicep
@@ -105,7 +105,7 @@ param scenario string = 'contoso_motors'
 param k8sWorkerNodesSku string = 'Standard_D8s_v5'
 //param k8sWorkerNodesSku string = deployGPUNodes ? 'Standard_NV4as_v4' : 'Standard_D8s_v5'
 
-param deployGPUNodes bool = false
+// param deployGPUNodes bool = false
 
 var templateBaseUrl = 'https://raw.githubusercontent.com/${githubAccount}/azure_arc/${githubBranch}/azure_jumpstart_ag/'
 var k3sClusterNodesCount = 2 // Number of nodes to deploy in the K3s cluster
@@ -149,6 +149,7 @@ module ubuntuRancherK3sDataSvcDeployment 'kubernetes/ubuntuRancher.bicep' = {
     storageContainerName: toLower(k3sArcDataClusterName)
     namingGuid: namingGuid
     scenario: scenario
+    influxDBPassword: windowsAdminPassword    
   }
 }
 
@@ -165,6 +166,7 @@ module ubuntuRancherK3sDeployment 'kubernetes/ubuntuRancher.bicep' = {
     storageContainerName: toLower(k3sArcClusterName)
     namingGuid: namingGuid
     scenario: scenario
+    influxDBPassword: windowsAdminPassword
   }
 }
 


### PR DESCRIPTION
Define influxDBPassword equal to windowsAdminPassword which is set in main.parameters.json

Without this, deployment stops with the following errors :

```
C:\Demos\azure_arc\azure_jumpstart_ag\contoso_motors\bicep\main.bicep(141,3) : Error BCP035: The specified "object" declaration is missing the following required properties: "influxDBPassword". [https://aka.ms/bicep/core-diagnostics#BCP035]
C:\Demos\azure_arc\azure_jumpstart_ag\contoso_motors\bicep\main.bicep(157,3) : Error BCP035: The specified "object" declaration is missing the following required properties: "influxDBPassword". [https://aka.ms/bicep/core-diagnostics#BCP035]
```

Commented line 108 in order to prevent warning

`C:\Demos\azure_arc\azure_jumpstart_ag\contoso_motors\bicep\main.bicep(108,7) : Warning no-unused-params: Parameter "deployGPUNodes" is declared but never used. [https://aka.ms/bicep/linter/no-unused-params]`