### PR TITLE
fix Helm 3.18.0 issue

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/Winget.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Winget.ps1
@@ -90,6 +90,13 @@ $Shortcut = $WScriptShell.CreateShortcut($ShortcutFile)
 $Shortcut.TargetPath = $TargetFile
 $Shortcut.Save()
 
+# Temporary fix for Helm 3.18.0
+Write-Header "Fixing Helm installation"
+Write-Host "`n"
+winget uninstall Helm.Helm
+winget install Helm.Helm --version 3.17.3 -s winget --silent --accept-package-agreements --accept-source-agreements --ignore-warnings
+
+
 # Start remaining logon scripts
 Get-ScheduledTask *LogonScript* | Start-ScheduledTask
 


### PR DESCRIPTION
this PR is a workaround to an issue introduced in Helm 3.18.0 that prevents the kube-prometheus-stack chart from being successfully deployed.  It reverts the winget install to use 3.17.3.  This workaround seems necessary since according to the Helm release  notes for [3.18.0](https://github.com/helm/helm/releases), 3.18.1 will be released on 11 June 2025.