### PR TITLE
Contoso Hypermarket - Update K3s to 1.33.0

### DIFF
--- a/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
+++ b/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
@@ -122,6 +122,19 @@ az -v
 
 check_dpkg_lock
 
+# Set prereqs for ACSA and  AIO
+
+echo fs.inotify.max_user_instances=8192 | sudo tee -a /etc/sysctl.conf
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
+echo fs.file-max=100000 | sudo tee -a /etc/sysctl.conf
+
+
+echo 512 | sudo tee /proc/sys/vm/nr_hugepages
+echo "vm.nr_hugepages=512" | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+
+sudo apt install linux-modules-extra-`uname -r`  -y
+
 if [[ "$k3sControlPlane" == "true" ]]; then
 
     # Installing Azure Arc extensions

--- a/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
+++ b/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
@@ -44,7 +44,7 @@ exec >installK3s-${vmName}.log
 exec 2>&1
 
 # Set k3 deployment variables
-export K3S_VERSION="1.29.6+k3s2" # Do not change!
+export K3S_VERSION="1.33.0+k3s1"
 
 chmod +x vars.sh
 . ./vars.sh


### PR DESCRIPTION
This PR bumps the K3s verson from 1.29.6 to 1.33.0.  In addition, the same sysctl tuning that was applied to Contoso Motors as part of [PR 3237](https://github.com/microsoft/azure_arc/pull/3237) has been done to improve the reliability of the Azure IoT Operations deployment.