### PR TITLE
Update integration test script

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
+++ b/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
@@ -29,48 +29,6 @@ Write-Output "Adding Storage Blob Data Contributor role assignment to SPN $env:s
 
 $null = Connect-AzAccount -Identity -Scope Process
 
-Write-Output "Wait for Azure CLI to become available (installed by WinGet)"
-
-# Starting time
-$startTime = Get-Date
-
-# Duration to wait (60 minutes)
-$duration = New-TimeSpan -Minutes 60
-
-do {
-    # Check if the path exists
-    $exists = Test-Path "C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin\az.cmd"
-
-    # Break if the path exists
-    if ($exists) {
-        Write-Host "File found."
-        break
-    }
-
-    # Wait for a short period before rechecking to avoid constant CPU usage
-    Start-Sleep -Seconds 30
-
-} while ((Get-Date) -lt $startTime.Add($duration))
-
-if (-not $exists) {
-    Write-Host "File not found within the 60-minute time frame."
-}
-
-# Get the current path
-$currentPath = $env:Path
-
-# Path to be added
-$newPath = "C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin"
-
-# Add the new path to the current session's Path environment variable
-$env:Path = $currentPath + ";" + $newPath
-
-Write-Output "Az CLI Login"
-az login --identity
-az account set -s $env:subscriptionId
-
-$ClientObjectId = Get-AzContext
-
 $StorageAccount = Get-AzStorageAccount -ResourceGroupName $env:resourceGroup
 
 # Get the VM's resource ID


### PR DESCRIPTION
This pull request removes unnecessary logic for waiting and configuring the Azure CLI in the `Send-PesterResult.ps1` script. The most important change simplifies the script by eliminating redundant checks and operations.

### Simplification of Azure CLI setup:

* Removed the entire block of code responsible for waiting for the Azure CLI to become available, which included checking for the CLI's installation path, waiting for up to 60 minutes, and updating the `Path` environment variable. This logic is no longer necessary and has been removed to streamline the script.