### PR TITLE
Arc Dashboard Deployment in 

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -51,6 +51,33 @@ $Shortcut.TargetPath = $LogsPath
 $shortcut.WindowStyle = 3
 $shortcut.Save()
 
+# Create desktop shortcut for Power BI Dashboard (ITPro flavor only)
+if ($Env:flavor -eq "ITPro") {
+
+    # Create Power Bi Report and Directory
+    if (-not (Test-Path $ArcBoxPBIDir)) {
+        New-Item -Path $ArcBoxPBIDir -ItemType Directory -Force
+        Write-Host "Created directory for Power BI Dashboard at $ArcBoxPBIDir"
+    } else {
+        Write-Host "Power BI Dashboard directory already exists at $ArcBoxPBIDir"
+    }
+
+    #Download Power BI dashboard from drops
+    Invoke-WebRequest ("https://github.com/Azure/arc_jumpstart_drops/raw/refs/heads/main/ui_dashboard_workbook/arc_pbi_dashboard/arc_insights_dashboard_jumpstart.pbit") -OutFile $ArcBoxPBIDir\ArcBoxDashboard.pbit
+
+    #Create shortcute for Power BI Dashboard
+    $PBIDashboardPath = "$ArcBoxPBIDir\ArcBoxDashboard.pbit"
+    if (Test-Path $PBIDashboardPath) {
+        $PBIShortcut = $WshShell.CreateShortcut("$Env:USERPROFILE\Desktop\ArcBox Power BI Dashboard.lnk")
+        $PBIShortcut.TargetPath = $PBIDashboardPath
+        $PBIShortcut.WindowStyle = 1
+        $PBIShortcut.Save()
+        Write-Host "Created desktop shortcut for Power BI Dashboard"
+    } else {
+        Write-Host "Power BI Dashboard file not found at $PBIDashboardPath"
+    }
+}
+
 # Configure Windows Terminal as the default terminal application
 $registryPath = 'HKCU:\Console\%%Startup'
 

--- a/azure_jumpstart_arcbox/artifacts/WinGet.ps1
+++ b/azure_jumpstart_arcbox/artifacts/WinGet.ps1
@@ -44,7 +44,11 @@ winget configure --file C:\ArcBox\DSC\common.dsc.yml --accept-configuration-agre
 switch ($env:flavor) {
     'DevOps' { winget configure --file C:\ArcBox\DSC\devops.dsc.yml --accept-configuration-agreements --disable-interactivity }
     'DataOps' { winget configure --file C:\ArcBox\DSC\dataops.dsc.yml --accept-configuration-agreements --disable-interactivity }
-    'ITPro' { winget configure --file C:\ArcBox\DSC\itpro.dsc.yml --accept-configuration-agreements --disable-interactivity }
+    'ITPro' { 
+                winget configure --file C:\ArcBox\DSC\itpro.dsc.yml --accept-configuration-agreements --disable-interactivity 
+                # install Power BI (does not support winget congigure) on ITPro flavor
+                winget install --id=Microsoft.PowerBI --silent --accept-package-agreements --accept-source-agreements
+            }
 }
 
 # Start remaining logon scripts


### PR DESCRIPTION
This set of changes affect the ITPro flavor of ArcBox and will allow the Arc Client machine to display the Arc Dashboard, which is a key feature for the users.

This change will:
Install Power BI Desktop on the Arc Client machine via script winget.ps1 (lines 49 -50)
Copy the Arc Dashboard to the Arc Client machine from current Arc Box drops via script ArcServerLogonScript.ps1 (lines 54-79) 

Note: that the current process of winget configure (+yaml) does not work for Power BI desktop install, only winget install

Arc Docs documentation Pull request is : https://github.com/Azure/arc_jumpstart_docs/pull/753