### PR TITLE
LocalBox 2507

### DIFF
--- a/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
@@ -28,8 +28,13 @@ Write-Host "[Build cluster - Step 1/11] Downloading LocalBox VHDs" -ForegroundCo
 $Env:AZCOPY_BUFFER_GB = 4
 Write-Output "Downloading nested VMs VHDX files. This can take some time, hold tight..."
 
+<#
 azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2506.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
 azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2506.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
+ #>
+azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2507.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
+azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2507.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
+
 
 $checksum = Get-FileHash -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx"
 $hash = Get-Content -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256"

--- a/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
@@ -28,13 +28,8 @@ Write-Host "[Build cluster - Step 1/11] Downloading LocalBox VHDs" -ForegroundCo
 $Env:AZCOPY_BUFFER_GB = 4
 Write-Output "Downloading nested VMs VHDX files. This can take some time, hold tight..."
 
-<#
-azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2506.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
-azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2506.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
- #>
-azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2507.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
-azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2507.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
-
+azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2507.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
+azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2507.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
 
 $checksum = Get-FileHash -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx"
 $hash = Get-Content -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256"


### PR DESCRIPTION
This pull request updates the version of the LocalBox VHD files being downloaded in the `New-LocalBoxCluster.ps1` script. The change ensures that the script uses the latest version of these files.

* [`azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1`](diffhunk://#diff-f52bdf86acc9470a021af04ea19816e27860f5e76388f5d71cda1102957d912cL31-R32): Updated the VHD and checksum file URLs from version `AzLocal2506` to `AzLocal2507` to download the latest LocalBox VHD files.

- Fixes https://github.com/microsoft/azure_arc/issues/3289