### PR TITLE
ArcBox - Windows SSH Posture

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
+++ b/azure_jumpstart_arcbox/artifacts/ArcServersLogonScript.ps1
@@ -701,6 +701,10 @@ if ($Env:flavor -ne 'DevOps') {
     }
 }
 
+# Triggering Azure Policy compliance scan
+Write-Header 'Triggering Azure Policy compliance scan'
+Start-AzPolicyComplianceScan -ResourceGroupName $resourceGroup -AsJob
+
 #Changing to Jumpstart ArcBox wallpaper
 Write-Header 'Changing wallpaper'
 

--- a/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
+++ b/azure_jumpstart_arcbox/artifacts/integration_tests/scripts/Send-PesterResult.ps1
@@ -27,10 +27,12 @@ switch ($env:flavor) {
 
 $null = Connect-AzAccount -Identity -Scope Process
 
-$StorageAccount = Get-AzStorageAccount -ResourceGroupName $env:resourceGroup
+$MetaData = (Invoke-RestMethod -Headers @{Metadata="true"} -Method GET -Uri "http://169.254.169.254/metadata/instance?api-version=2021-02-01").compute
 
-# Get the VM's resource ID
-$vmResourceId = (Invoke-RestMethod -Headers @{Metadata="true"} -Method GET -Uri "http://169.254.169.254/metadata/instance?api-version=2021-02-01").compute.resourceId
+$vmResourceId = $MetaData.resourceId
+$resourceGroup = $MetaData.resourceGroupName
+
+$StorageAccount = Get-AzStorageAccount -ResourceGroupName $resourceGroup
 
 # Get the VM resource
 $vm = Get-AzResource -ResourceId $vmResourceId

--- a/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_arcbox/bicep/clientVm/clientVm.bicep
@@ -338,4 +338,4 @@ resource autoShutdown 'Microsoft.DevTestLab/schedules@2018-09-15' = if (autoShut
 }
 
 output adminUsername string = windowsAdminUsername
-output publicIP string = deployBastion == false ? concat(publicIpAddress.properties.ipAddress) : ''
+output publicIP string = deployBastion == false ? publicIpAddress!.properties.ipAddress : ''

--- a/azure_jumpstart_localbox/bicep/host/host.bicep
+++ b/azure_jumpstart_localbox/bicep/host/host.bicep
@@ -323,4 +323,4 @@ resource deployerRoleAssignment_StorageAccountContributor 'Microsoft.Authorizati
 }
 
 output adminUsername string = windowsAdminUsername
-output publicIP string = deployBastion == false ? concat(publicIpAddress.properties.ipAddress) : ''
+output publicIP string = deployBastion == false ? publicIpAddress!.properties.ipAddress : ''


### PR DESCRIPTION
This pull request introduces several improvements and updates to the Bicep templates for Azure Jumpstart ArcBox and LocalBox, focusing on policy management, parameter clarity, and output handling. The main changes include better separation and assignment of SSH Posture Control policies for Linux and Windows, the addition of a prerequisite policy for Azure Machine Configuration, and minor code improvements for output and property access.

**Policy Management Enhancements:**

* Split the SSH Posture Control policy into separate parameters and policy assignments for Linux and Windows, providing clearer configuration and support for both platforms (`sshPostureControlLinuxAzurePolicyId`, `sshPostureControlWindowsAzurePolicyId`, new resource assignments for each) [[1]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L17-R19) [[2]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L206-R261).
* Added a new parameter and policy assignment for Azure Machine Configuration prerequisites, including a managed identity and a corresponding role assignment (`azureMachineConfigurationPrerequisitePolicyId`, new policy and role assignment resources) [[1]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L17-R19) [[2]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L206-R261).

**Code Quality and Output Improvements:**

* Updated output expressions for `publicIP` in both `clientVm.bicep` and `host.bicep` to use the non-null assertion operator (`!`), ensuring safer property access [[1]](diffhunk://#diff-db7ddb891dea059a7a5630ee36842f00a9d7fa9e6e96a1873867bdcf3a7dda58L341-R341) [[2]](diffhunk://#diff-ba4e20f1c429a1f1caa6bf5e5bcc78a03b7f62ab409290afce4f5048794e52a2L326-R326).
* Improved robustness of role assignment resource definitions by using the non-null assertion operator for identity property access (`policies_name[0]!.identity.principalId`, etc.) [[1]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L69-R71) [[2]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L78-R80) [[3]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L87-R89) [[4]](diffhunk://#diff-27fa782749c8afafa5f903e0df5e946399f2ba91ce62af3945f3705de59bc519L96-R98).

- Fixes #3292 
- Fixes #3276