### PR TITLE
Update host.bicep - publicIpAddress sku from Basic to Standard

### DIFF
--- a/azure_jumpstart_localbox/bicep/host/host.bicep
+++ b/azure_jumpstart_localbox/bicep/host/host.bicep
@@ -124,7 +124,7 @@ resource publicIpAddress 'Microsoft.Network/publicIpAddresses@2021-03-01' = if (
     idleTimeoutInMinutes: 4
   }
   sku: {
-    name: 'Basic'
+    name: 'Standard'
   }
   tags: resourceTags
 }


### PR DESCRIPTION
Updated publicIpAddress sku from Basic to Standard

Reasoning:
There's no more basic SKU hence it errors out when you deploy