### PR TITLE
Pin WinGet PowerShell modules to version 1.11.460 to avoid known issue

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/Winget.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Winget.ps1
@@ -9,7 +9,8 @@ $logFilePath = Join-Path -Path $AgLogsDir -ChildPath ('WinGet-provisioning-' + (
 Start-Transcript -Path $logFilePath -Force -ErrorAction SilentlyContinue
 
 # Install WinGet PowerShell modules
-Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+# Pinned to version 1.11.460 to avoid known issue: https://github.com/microsoft/winget-cli/issues/5826
+Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.11.460
 
 # Install WinGet CLI
 $null = Repair-WinGetPackageManager -AllUsers -Force -Latest

--- a/azure_jumpstart_arcbox/artifacts/WinGet.ps1
+++ b/azure_jumpstart_arcbox/artifacts/WinGet.ps1
@@ -26,8 +26,9 @@ $null = Set-AzResourceGroup -ResourceGroupName $resourceGroup -Tag $tags
 $null = Set-AzResource -ResourceName $env:computername -ResourceGroupName $resourceGroup -ResourceType "microsoft.compute/virtualmachines" -Tag $tags -Force
 
 # Install WinGet PowerShell modules
-Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
-Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+# Pinned to version 1.11.460 to avoid known issue: https://github.com/microsoft/winget-cli/issues/5826
+Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.11.460
+Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.11.460
 
 # Install DSC resources required for ArcBox
 Install-PSResource -Name DSCR_Font -Scope AllUsers -Quiet -AcceptLicense -TrustRepository

--- a/azure_jumpstart_localbox/artifacts/PowerShell/WinGet.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/WinGet.ps1
@@ -15,8 +15,9 @@ Connect-AzAccount -Identity -Tenant $Env:tenantId -Subscription $Env:subscriptio
 Update-AzDeploymentProgressTag -ProgressString 'Installing WinGet packages...' -ResourceGroupName $env:resourceGroup -ComputerName $env:computername
 
 # Install WinGet PowerShell modules
-Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
-Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+# Pinned to version 1.11.460 to avoid known issue: https://github.com/microsoft/winget-cli/issues/5826
+Install-PSResource -Name Microsoft.WinGet.Client -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.11.460
+Install-PSResource -Name Microsoft.WinGet.DSC -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Version 1.11.460
 
 # Install DSC resources required for ArcBox
 Install-PSResource -Name DSCR_Font -Scope AllUsers -Quiet -AcceptLicense -TrustRepository


### PR DESCRIPTION
This pull request addresses a known issue with the latest versions of the WinGet PowerShell modules by pinning the installation to version 1.11.460 across several provisioning scripts. This ensures consistency and avoids breaking changes due to upstream issues.

Dependency management and reliability improvements:

* Updated `Install-PSResource` commands in `azure_jumpstart_ag/artifacts/PowerShell/Winget.ps1`, `azure_jumpstart_arcbox/artifacts/WinGet.ps1`, and `azure_jumpstart_localbox/artifacts/PowerShell/WinGet.ps1` to explicitly install `Microsoft.WinGet.Client` and `Microsoft.WinGet.DSC` at version 1.11.460, with a comment referencing the related GitHub issue. [[1]](diffhunk://#diff-189e9239ef746e1c31d9c5e55dbde18cc30392c5ff265120f1f3b857baf0cb05L12-R13) [[2]](diffhunk://#diff-052ac08b482fd0b1856485ecfb9c7e5d4a40e265a0f80bced64db99e149edafdL29-R31) [[3]](diffhunk://#diff-677cb086df59344d8f362aae32b8c9ec23ba2973855bdb0f995935f756c8906dL18-R20)

- Fixes #3328 