### PR TITLE
ArcBox - Issue 3359 - additional enhancements

### DIFF
--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -132,6 +132,14 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
 
 # Pin Az-modules after other modules to avoid version conflicts
+# Install Az modules (excluding Az.Accounts which will be pinned separately)
+$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
+
+foreach ($module in $modules) {
+    Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+}
+
+# Pin Az.Accounts and Az.KeyVault after other modules to avoid version conflicts
 # See: https://github.com/microsoft/azure_arc/issues/3359
 Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
@@ -144,6 +152,9 @@ Install-PSResource -Name Microsoft.PowerShell.SecretManagement -Version 1.1.2 -S
 Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
 Import-Module Az.KeyVault -RequiredVersion 6.4.1 -Force
 Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
+Import-Module Az.Compute -RequiredVersion 11.1.0 -Force
+Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
+Import-Module Az.Storage -RequiredVersion 9.4.0 -Force
 
 $DeploymentProgressString = "Started bootstrap-script..."
 

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -132,7 +132,7 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
 
 # Install Az modules (excluding Az.Accounts which will be pinned separately)
-$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Az.Resources", "Az.KeyVault", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
+$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
 
 foreach ($module in $modules) {
     Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
@@ -142,10 +142,14 @@ foreach ($module in $modules) {
 # See: https://github.com/microsoft/azure_arc/issues/3359
 Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.Compute -Version 11.1.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.Resources -Version 9.0.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 
 # Import the module to ensure the correct version is loaded
 Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
 Import-Module Az.KeyVault -RequiredVersion 6.4.1 -Force
+Import-Module Az.Compute -RequiredVersion 11.1.0 -Force
+Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
 
 # Add Key Vault Secrets
 Connect-AzAccount -Identity

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -144,12 +144,15 @@ Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -Acce
 Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.Compute -Version 11.1.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.Resources -Version 9.0.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.Storage -Version 9.4.0  -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+
 
 # Import the module to ensure the correct version is loaded
 Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
 Import-Module Az.KeyVault -RequiredVersion 6.4.1 -Force
 Import-Module Az.Compute -RequiredVersion 11.1.0 -Force
 Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
+Import-Module Az.Storage -RequiredVersion 9.4.0 -Force
 
 # Add Key Vault Secrets
 Connect-AzAccount -Identity

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -131,14 +131,19 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
 
-# Pin due to incompatibility issues with version 5.3.2: https://github.com/microsoft/azure_arc/issues/3359
-Install-Module -Name Az.Accounts -RequiredVersion 5.3.1 -Force
-
-$modules = @("Az", "Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
+# Install Az modules (excluding Az.Accounts which will be pinned separately)
+$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Az.Resources", "Az.KeyVault", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
 
 foreach ($module in $modules) {
     Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
 }
+
+# Pin Az.Accounts AFTER other modules to avoid version conflicts
+# See: https://github.com/microsoft/azure_arc/issues/3359
+Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+
+# Import the module to ensure the correct version is loaded
+Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
 
 # Add Key Vault Secrets
 Connect-AzAccount -Identity

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -132,27 +132,18 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
 
 # Pin Az-modules after other modules to avoid version conflicts
-# Install Az modules (excluding Az.Accounts which will be pinned separately)
-$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
-
-foreach ($module in $modules) {
-    Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
-}
-
-# Pin Az.Accounts and Az.KeyVault after other modules to avoid version conflicts
 # See: https://github.com/microsoft/azure_arc/issues/3359
 Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.Compute -Version 11.1.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.Resources -Version 9.0.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.Storage -Version 9.4.0  -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Microsoft.PowerShell.SecretManagement -Version 1.1.2 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 
 # Import the module to ensure the correct version is loaded
 Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
 Import-Module Az.KeyVault -RequiredVersion 6.4.1 -Force
-Import-Module Az.Compute -RequiredVersion 11.1.0 -Force
 Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
-Import-Module Az.Storage -RequiredVersion 9.4.0 -Force
 
 $DeploymentProgressString = "Started bootstrap-script..."
 

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -147,6 +147,8 @@ Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
 
 $DeploymentProgressString = "Started bootstrap-script..."
 
+Connect-AzAccount -Identity
+
 $tags = Get-AzResourceGroup -Name $resourceGroup | Select-Object -ExpandProperty Tags
 
 if ($null -ne $tags) {

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -138,12 +138,14 @@ foreach ($module in $modules) {
     Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
 }
 
-# Pin Az.Accounts AFTER other modules to avoid version conflicts
+# Pin Az.Accounts and Az.KeyVault after other modules to avoid version conflicts
 # See: https://github.com/microsoft/azure_arc/issues/3359
 Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 
 # Import the module to ensure the correct version is loaded
 Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
+Import-Module Az.KeyVault -RequiredVersion 6.4.1 -Force
 
 # Add Key Vault Secrets
 Connect-AzAccount -Identity

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -130,6 +130,10 @@ Resize-Partition -DriveLetter C -Size $(Get-PartitionSupportedSize -DriveLetter 
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
+
+# Pin due to incompatibility issues with version 5.3.2: https://github.com/microsoft/azure_arc/issues/3359
+Install-Module -Name Az.Accounts -RequiredVersion 5.3.1 -Force
+
 $modules = @("Az", "Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
 
 foreach ($module in $modules) {

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -205,7 +205,7 @@ if ($autoShutdownEnabled -eq "true") {
 
 }
 
-# Installing tools
+# Installing tools and module
 
 Write-Header "Installing PowerShell 7"
 

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -131,13 +131,6 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
 
-# Install Az modules (excluding Az.Accounts which will be pinned separately)
-$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Microsoft.PowerShell.SecretManagement", "Pester")
-
-foreach ($module in $modules) {
-    Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
-}
-
 # Pin Az.Accounts and Az.KeyVault after other modules to avoid version conflicts
 # See: https://github.com/microsoft/azure_arc/issues/3359
 Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
@@ -145,13 +138,12 @@ Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -Acce
 Install-PSResource -Name Az.Compute -Version 11.1.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.Resources -Version 9.0.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.Storage -Version 9.4.0  -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Microsoft.PowerShell.SecretManagement -Version 1.1.2 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 
 # Import the module to ensure the correct version is loaded
 Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
 Import-Module Az.KeyVault -RequiredVersion 6.4.1 -Force
-Import-Module Az.Compute -RequiredVersion 11.1.0 -Force
 Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
-Import-Module Az.Storage -RequiredVersion 9.4.0 -Force
 
 $DeploymentProgressString = "Started bootstrap-script..."
 
@@ -226,6 +218,13 @@ Start-Process msiexec.exe -Wait -ArgumentList '/I PowerShell7.msi /quiet ADD_EXP
 Remove-Item .\PowerShell7.msi
 
 Copy-Item $PsHome\Profile.ps1 -Destination "C:\Program Files\PowerShell\7\"
+
+
+$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Pester")
+
+foreach ($module in $modules) {
+    Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+}
 
 Write-Header "Fetching GitHub Artifacts"
 

--- a/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
+++ b/azure_jumpstart_arcbox/artifacts/Bootstrap.ps1
@@ -131,7 +131,7 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
 
-# Pin Az.Accounts and Az.KeyVault after other modules to avoid version conflicts
+# Pin Az-modules after other modules to avoid version conflicts
 # See: https://github.com/microsoft/azure_arc/issues/3359
 Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
 Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall

--- a/azure_jumpstart_arcbox/artifacts/installArcAgentSQLUser.ps1
+++ b/azure_jumpstart_arcbox/artifacts/installArcAgentSQLUser.ps1
@@ -1,0 +1,212 @@
+﻿param ($servicePrincipalAppId, $servicePrincipalTenantId, $servicePrincipalSecret)
+
+# These settings will be replaced by the portal when the script is generated
+$subId = "<subscriptionId>"
+$resourceGroup = "<resourceGroup>"
+$location = "<location>"
+$proxy=""
+$resourceTags= @{}
+$arcMachineName = [Environment]::MachineName
+
+# These optional variables can be replaced with valid service principal details
+# if you would like to use this script for a registration at scale scenario, i.e. run it on multiple machines remotely
+# For more information, see https://learn.microsoft.com/sql/sql-server/azure-arc/connect-at-scale
+#
+# For security purposes, passwords should be stored in encrypted files as secure strings
+#
+#$servicePrincipalAppId = ''
+#$servicePrincipalTenantId = ''
+#$servicePrincipalSecret = ''
+
+$unattended = $servicePrincipalAppId -And $servicePrincipalTenantId -And $servicePrincipalSecret
+$ErrorActionPreference = 'Stop'
+
+function Install-PowershellModule() {
+    # Ask for user confirmation if running manually
+    #
+    if ( ! $unattended) {
+        $title = 'Confirm Dependency Installation'
+        $question = 'The Azure PowerShell Module is required in order to register SQL Server - Azure Arc resources. Would you like to install it now?'
+        $choices = '&Yes', '&No'
+
+        $decision = $Host.UI.PromptForChoice($title, $question, $choices, 1)
+        if ($decision -eq 1) {
+            Write-Warning "Azure module install declined."
+            return
+        }
+    }
+    # Check if requirements are met for Powershell module install
+    #
+    $version = $PSVersionTable.PSVersion
+    if ([version]$version -lt [version]"5.1") {
+        Write-Warning -Category NotInstalled -Message "Could not install Az module: Az module requires Powershell version 5.1.* or above."
+        return
+    }
+    if ($PSVersionTable.PSEdition -eq 'Desktop' -and (Get-Module -Name AzureRM -ListAvailable)) {
+        if ([version]$version -lt [version]"6.2.4") {
+            Write-Warning -Category NotInstalled -Message ("Could not install Az module: Powershell $version does not support having both the AzureRM and Az modules installed. " +
+                "If you need to keep AzureRM available on your system, install the Az module for PowerShell 6.2.4 or later. " +
+                "For more information, see: https://learn.microsoft.com/powershell/azure/migrate-from-azurerm-to-az")
+            return
+        }
+
+        Write-Warning -Message "The Az module will be installed alongside the existing AzureRM module."
+    }
+
+    Write-Verbose "Installing Az module for PowerShell"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+    Install-Module -Name Az -AllowClobber -Scope CurrentUser -Force
+}
+
+# Confirm that Azure powershell module is installed, and install if not present
+#
+if (-Not (Get-InstalledModule -Name Az -MinimumVersion 8.0.0 -ErrorAction SilentlyContinue)) {
+    Install-PowershellModule
+    if (-Not (Get-InstalledModule -Name Az -ErrorAction SilentlyContinue)) {
+        Write-Warning -Category NotInstalled -Message "Failed to install Azure Powershell Module. Please confirm that Az module is installed before continuing."
+        return
+    }
+}
+else
+{
+    Write-Verbose "Az already installed. Skipping installation."
+}
+
+if (-Not (Get-InstalledModule -Name Az.ConnectedMachine -MinimumVersion 0.4.0 -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing Az.connectedMachine module."
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Find-Module -Name Az.ConnectedMachine | Install-Module -Force
+}
+else
+{
+    Write-Verbose "Az.ConnectedMachine already installed. Skipping installation."
+}
+
+if (-Not (Get-InstalledModule -Name Az.Resources -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing Az.Resources module."
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Find-Module -Name Az.Resources | Install-Module -Force
+}
+else
+{
+    Write-Verbose "Az.Resources already installed. Skipping installation."
+}
+
+# For manual Azure Arc registration, an access token prevents a duplicate Azure login
+# Getting an access token is only supported in Az.Accounts 2.2 or up
+#
+if (-Not (Get-InstalledModule -Name Az.Accounts -MinimumVersion 2.2 -ErrorAction SilentlyContinue) -and -Not $unattended) {
+    Write-Warning "For the best user experience, we recommend updating the Az.Accounts module. Please confirm installation."
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-Module -Name Az.Accounts -MinimumVersion 2.2 -Confirm -Force
+}
+
+# Confirm that user is signed in to Azure powershell module
+#
+$context = Get-AzContext
+if (!$context) {
+    if ($unattended) {
+        $securePassword = $servicePrincipalSecret
+        if ($servicePrincipalSecret -is [String]) {
+            Write-Warning -Message "Saving a plaintext password presents a security risk. Consider storing your password in a secure file."
+            $securePassword = ConvertTo-SecureString -String $servicePrincipalSecret -AsPlainText -Force
+        }
+        $pscredential = New-Object -TypeName System.Management.Automation.PSCredential($servicePrincipalAppId, $securePassword)
+        Connect-AzAccount -ServicePrincipal -Credential $pscredential -Tenant $servicePrincipalTenantId
+    }
+    else {
+        Write-Host "Please connect your Azure account."
+        Connect-AzAccount -UseDeviceAuthentication
+    }
+    $context = Get-AzContext
+    if (!$context) {
+        Write-Warning -Category AuthenticationError -Message "Please connect your Azure account with `"Connect-AzAccount`" before continuing."
+        return
+    }
+}
+
+if (-Not (Set-AzContext -Subscription $subId -ErrorAction SilentlyContinue)) {
+    Write-Warning "Unable to set context to $subId. It is possible that given subscription not found in logged in context."
+    return
+}
+
+$roleWritePermissions = Get-AzRoleAssignment -Scope "/subscriptions/$subId/resourcegroups/$resourceGroup/providers/Microsoft.Authorization/roleAssignments/write"
+
+if(!$roleWritePermissions)
+{
+    Write-Warning "User does not have permissions to assign roles. This is pre-requisite to on board SQL Server - Azure Arc resources."
+    return
+}
+
+
+# Check if the machine is registered with Azure Arc-enabled servers
+# Register machine if necessary
+#
+$arcResource = Get-AzConnectedMachine -ResourceGroupName $resourceGroup -Name $arcMachineName -ErrorAction SilentlyContinue
+
+if ($null -eq $arcResource) {
+    Write-Host "Arc for Servers resource not found. Registering the current machine now."
+    $params = @{
+        ResourceGroupName=$resourceGroup
+        Name=$arcMachineName
+        Location=$location
+    }
+    if ($proxy) {
+        $params['Proxy'] = $proxy
+    }
+
+    Connect-AzConnectedMachine @params -ErrorAction SilentlyContinue
+}
+
+$arcResource = Get-AzConnectedMachine -ResourceGroupName $resourceGroup -Name $arcMachineName -ErrorAction SilentlyContinue
+
+if (!$arcResource) {
+    Write-Warning -Message "Failed to register the machine with Azure Arc-enabled servers. Exiting."
+    return
+}
+
+Write-Verbose "Getting managed Identity ID of $arcMachineName."
+
+$spID = $arcResource.IdentityPrincipalId
+
+
+if($null -eq $spID) {
+    Write-Warning -Message "Failed to get $arcMacineName Identity Id. Please check if Arc machine exist and rerun this step."
+    return
+}
+
+$currentRoleAssignment = Get-AzRoleAssignment -RoleDefinitionName "Azure Connected SQL Server Onboarding" -ObjectId $spID -ResourceGroupName $resourceGroup
+
+$retryCount = 6
+$count = 0
+$waitTimeInSeconds = 10
+
+while(!$currentRoleAssignment -and $count -le $retryCount)
+{
+    Write-Host "Arc machine managed Identity does not have Azure Connected SQL Server Onboarding role. Assigning it now."
+    $currentRoleAssignment = New-AzRoleAssignment -ObjectId $spID -RoleDefinitionName "Azure Connected SQL Server Onboarding" -ResourceGroupName $resourceGroup -ErrorAction SilentlyContinue
+    sleep $waitTimeInSeconds
+    $count++
+}
+
+if(!$currentRoleAssignment)
+{
+    Write-Verbose "Unable to assign Azure Connected SQL Server Onboarding role to Arc managed Identity. Skipping role assignment."
+    return
+}
+
+
+Write-Host "Installing SQL Server - Azure Arc extension. This may take 5+ minutes."
+
+$settings = @{ SqlManagement = @{ IsEnabled = $true }}
+
+$result = New-AzConnectedMachineExtension -Name "WindowsAgent.SqlServer" -ResourceGroupName $resourceGroup -MachineName $arcMachineName -Location $location -Publisher "Microsoft.AzureData" -Settings $settings -ExtensionType "WindowsAgent.SqlServer" -Tag $resourceTags
+
+if($result.ProvisioningState -eq "Failed")
+{
+    Write-Warning "Extension Installation Failed. Arc enabled SQL server instances will not be created. Please find more information below."
+    $result
+}
+
+Write-Host "SQL Server - Azure Arc resources should show up in resource group in less than 1 minute."

--- a/azure_jumpstart_localbox/artifacts/PowerShell/integration_tests/scripts/Wait-LocalBoxDeployment.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/integration_tests/scripts/Wait-LocalBoxDeployment.ps1
@@ -19,7 +19,7 @@ if ($existingJob) {
     Set-AzVMRunCommand -ResourceGroupName $ResourceGroupName -VMName LocalBox-Client -RunCommandName RetrievePesterResults -Location $Location -SourceScriptUri "https://raw.githubusercontent.com/$githubAccount/azure_arc/$githubBranch/azure_jumpstart_localbox/artifacts/PowerShell/integration_tests/scripts/Send-PesterResult.ps1" -AsyncExecution
 }
 
-$timeoutMinutes = 360 # 6 hours timeout
+$timeoutMinutes = 480 # 8 hours timeout
 $elapsedMinutes = 0
 
 do {


### PR DESCRIPTION
This pull request updates the PowerShell bootstrap and integration test scripts to improve module installation reliability and extend deployment timeouts. The main changes focus on pinning specific module versions to avoid conflicts, reorganizing module installation steps, and increasing the deployment timeout for integration tests.

**Module installation improvements:**

* Pinned the installation of key Az modules (`Az.Accounts`, `Az.KeyVault`, `Az.Compute`, `Az.Resources`, `Az.Storage`, and `Microsoft.PowerShell.SecretManagement`) to specific versions using explicit `Install-PSResource` commands in `Bootstrap.ps1` to prevent version conflicts. (`azure_jumpstart_arcbox/artifacts/Bootstrap.ps1`, [azure_jumpstart_arcbox/artifacts/Bootstrap.ps1L134-R146](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707L134-R146))
* Moved the installation of remaining modules (`Az.ConnectedMachine`, `Az.ConnectedKubernetes`, `Az.CustomLocation`, `Azure.Arc.Jumpstart.Common`, `Pester`) to later in the script, after the core modules are pinned. (`azure_jumpstart_arcbox/artifacts/Bootstrap.ps1`, [azure_jumpstart_arcbox/artifacts/Bootstrap.ps1R222-R228](diffhunk://#diff-e1566751716f7ef2987dbd1caef5f6cc42666a60cdab771f7b55a0c3164ed707R222-R228))

**Integration test improvements:**

* Increased the deployment timeout from 6 hours to 8 hours in the integration test script to accommodate longer-running deployments. (`azure_jumpstart_localbox/artifacts/PowerShell/integration_tests/scripts/Wait-LocalBoxDeployment.ps1`, [azure_jumpstart_localbox/artifacts/PowerShell/integration_tests/scripts/Wait-LocalBoxDeployment.ps1L22-R22](diffhunk://#diff-3253f0c9a0eaedb49faa14df04ecd34deff3c952e99f452b877d6999a35a5613L22-R22))