### PR TITLE
LocalBox 2601

### DIFF
--- a/azure_jumpstart_localbox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/Bootstrap.ps1
@@ -183,7 +183,7 @@ Remove-Item .\PowerShell7.msi
 
 Copy-Item $PsHome\Profile.ps1 -Destination "C:\Program Files\PowerShell\7\"
 
-$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Azure.Arc.Jumpstart.LocalBox", "Pester")
+$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.StackHCI", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Azure.Arc.Jumpstart.LocalBox", "Pester")
 
 foreach ($module in $modules) {
     Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository

--- a/azure_jumpstart_localbox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/Bootstrap.ps1
@@ -138,11 +138,20 @@ Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 Write-Host "Installing PowerShell modules..."
 
 Install-Module -Name Microsoft.PowerShell.PSResourceGet -Force
-$modules = @("Az", "Az.ConnectedMachine", "Azure.Arc.Jumpstart.Common", "Azure.Arc.Jumpstart.LocalBox", "Microsoft.PowerShell.SecretManagement", "Pester")
 
-foreach ($module in $modules) {
-    Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
-}
+# Pin Az-modules after other modules to avoid version conflicts
+# See: https://github.com/microsoft/azure_arc/issues/3359
+Install-PSResource -Name Az.Accounts -Version 5.3.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.KeyVault -Version 6.4.1 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.Compute -Version 11.1.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.Resources -Version 9.0.0 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Az.Storage -Version 9.4.0  -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+Install-PSResource -Name Microsoft.PowerShell.SecretManagement -Version 1.1.2 -Scope AllUsers -Quiet -AcceptLicense -TrustRepository -Reinstall
+
+# Import the module to ensure the correct version is loaded
+Import-Module Az.Accounts -RequiredVersion 5.3.1 -Force
+Import-Module Az.KeyVault -RequiredVersion 6.4.1 -Force
+Import-Module Az.Resources -RequiredVersion 9.0.0 -Force
 
 Connect-AzAccount -Identity
 
@@ -173,6 +182,12 @@ Start-Process msiexec.exe -Wait -ArgumentList '/I PowerShell7.msi /quiet ADD_EXP
 Remove-Item .\PowerShell7.msi
 
 Copy-Item $PsHome\Profile.ps1 -Destination "C:\Program Files\PowerShell\7\"
+
+$modules = @("Az.ConnectedMachine", "Az.ConnectedKubernetes", "Az.CustomLocation", "Azure.Arc.Jumpstart.Common", "Azure.Arc.Jumpstart.LocalBox", "Pester")
+
+foreach ($module in $modules) {
+    Install-PSResource -Name $module -Scope AllUsers -Quiet -AcceptLicense -TrustRepository
+}
 
 # Disabling Windows Server Manager Scheduled Task
 Write-Host "Disabling Windows Server Manager scheduled task."

--- a/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
@@ -28,8 +28,11 @@ Write-Host "[Build cluster - Step 1/11] Downloading LocalBox VHDs" -ForegroundCo
 $Env:AZCOPY_BUFFER_GB = 4
 Write-Output "Downloading nested VMs VHDX files. This can take some time, hold tight..."
 
-azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
-azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
+#azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
+#azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
+
+azcopy cp 'https://azlocalvhdx657231709.blob.core.windows.net/vhdx/AzLocal2601.vhdx?sv=2025-07-05&spr=https&st=2026-01-23T19%3A43%3A28Z&se=2026-01-30T19%3A43%3A00Z&sr=b&sp=r&sig=dPfHZBYmS7wbp7bmsjO718QYcpXz0jHcCxWyLHKkaOg%3D' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
+azcopy cp 'https://azlocalvhdx657231709.blob.core.windows.net/vhdx/AzLocal2601.sha256?sv=2025-07-05&spr=https&st=2026-01-23T19%3A42%3A44Z&se=2026-01-30T19%3A42%3A00Z&sr=b&sp=r&sig=2b99h9fpZYYXSeOnB%2FAJGQ2G3tHvFTyfHAa5VXj%2Bhtk%3D' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
 
 $checksum = Get-FileHash -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx"
 $hash = Get-Content -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256"

--- a/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
@@ -31,8 +31,8 @@ Write-Output "Downloading nested VMs VHDX files. This can take some time, hold t
 #azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
 #azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
 
-azcopy cp 'https://azlocalvhdx657231709.blob.core.windows.net/vhdx/AzLocal2601.vhdx?sv=2025-07-05&spr=https&st=2026-01-23T19%3A43%3A28Z&se=2026-01-30T19%3A43%3A00Z&sr=b&sp=r&sig=dPfHZBYmS7wbp7bmsjO718QYcpXz0jHcCxWyLHKkaOg%3D' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
-azcopy cp 'https://azlocalvhdx657231709.blob.core.windows.net/vhdx/AzLocal2601.sha256?sv=2025-07-05&spr=https&st=2026-01-23T19%3A42%3A44Z&se=2026-01-30T19%3A42%3A00Z&sr=b&sp=r&sig=2b99h9fpZYYXSeOnB%2FAJGQ2G3tHvFTyfHAa5VXj%2Bhtk%3D' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
+azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2601.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
+azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2601.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
 
 $checksum = Get-FileHash -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx"
 $hash = Get-Content -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256"

--- a/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
@@ -191,6 +191,9 @@ Set-AzLocalDeployPrereqs -LocalBoxConfig $LocalBoxConfig -localCred $localCred -
 
 Write-Host "[Build cluster - Step 10/11] Validate cluster deployment..." -ForegroundColor Green
 
+# Wait before starting validation to allow Connected Machines to register device information
+Start-Sleep -Seconds 600
+
 if ("True" -eq $env:autoDeployClusterResource) {
 
 Update-AzDeploymentProgressTag -ProgressString 'Validating Azure Local cluster deployment' -ResourceGroupName $env:resourceGroup -ComputerName $env:computername

--- a/azure_jumpstart_localbox/artifacts/PowerShell/tests/Invoke-Test.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/tests/Invoke-Test.ps1
@@ -14,7 +14,7 @@ function Wait-AzDeployment {
         [Parameter(Mandatory = $true)]
         [string]$ClusterName,
 
-        [int]$TimeoutMinutes = 240  # Default timeout of 4 hours
+        [int]$TimeoutMinutes = 480  # Default timeout of 8 hours
     )
 
     $startTime = Get-Date
@@ -163,7 +163,7 @@ Write-Header 'Adding deployment test results to wallpaper using BGInfo'
 Set-Content "$Env:windir\TEMP\localbox-tests-succeeded.txt" $tests_passed
 Set-Content "$Env:windir\TEMP\localbox-tests-failed.txt" $tests_failed
 
-bginfo.exe $Env:LocalBoxTestsDir\localbox-bginfo.bgi /timer:0 /NOLICPROMPT
+bginfo64.exe $Env:LocalBoxTestsDir\localbox-bginfo.bgi /timer:0 /NOLICPROMPT
 
 # Setup scheduled task for running tests on each logon
 $TaskName = 'Pester tests'


### PR DESCRIPTION
This pull request updates several PowerShell scripts to improve module installation reliability, update VM image sources, and enhance deployment robustness for Azure Jumpstart LocalBox. The main changes focus on pinning specific module versions to avoid conflicts, updating the source and version of VM images, and increasing deployment/test timeouts for better stability.

**PowerShell module installation and management:**

* Refactored `Bootstrap.ps1` to pin specific versions of Az modules and `Microsoft.PowerShell.SecretManagement`, installing them individually and importing them to ensure correct versions are loaded. This helps prevent version conflicts, especially with Az modules.
* Moved installation of remaining modules (`Az.ConnectedMachine`, `Az.ConnectedKubernetes`, `Az.StackHCI`, `Az.CustomLocation`, `Azure.Arc.Jumpstart.Common`, `Azure.Arc.Jumpstart.LocalBox`, `Pester`) to a separate section after Az modules are installed.

**VM image source and version updates:**

* Updated `New-LocalBoxCluster.ps1` to use new VM image URLs (`AzLocal2601.vhdx` and its `.sha256`), replacing the previous `AzLocal2509` images. This ensures the latest VM build is used.

**Deployment and validation robustness:**

* Added a 10-minute wait (`Start-Sleep -Seconds 600`) before cluster deployment validation to allow Connected Machines to register device information, reducing race conditions in cluster setup.
* Increased the default deployment timeout in `Invoke-Test.ps1` from 4 hours to 8 hours to accommodate longer deployments.

**Test and reporting improvements:**

* Changed wallpaper test result reporting to use `bginfo64.exe` instead of `bginfo.exe`, improving compatibility with 64-bit systems.

**Issues**

- Fixes #3367 
- Fixes #3365 