### PR TITLE
fix(localbox): improve deployment reliability — VHDX copy, VM verification, task trigger, RP polling, SYSTEM context

### DIFF
--- a/azure_jumpstart_localbox/artifacts/PowerShell/Bootstrap.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/Bootstrap.ps1
@@ -236,8 +236,9 @@ Register-ScheduledTask -TaskName "WinGetLogonScript" -Trigger $Trigger -User $ad
 
 # Creating scheduled task for LocalBoxLogonScript.ps1
 Write-Host "Creating scheduled task for LocalBoxLogonScript.ps1"
+$Trigger = New-ScheduledTaskTrigger -AtLogOn
 $Action = New-ScheduledTaskAction -Execute $ScheduledTaskExecutable -Argument $LocalBoxPath\LocalBoxLogonScript.ps1
-Register-ScheduledTask -TaskName "LocalBoxLogonScript"  -User $adminUsername -Action $Action -RunLevel "Highest" -Force
+Register-ScheduledTask -TaskName "LocalBoxLogonScript" -Trigger $Trigger -User $adminUsername -Action $Action -RunLevel "Highest" -Force
 
 # Disable Edge 'First Run' Setup
 Write-Host "Configuring Microsoft Edge."

--- a/azure_jumpstart_localbox/artifacts/PowerShell/LocalBoxLogonScript.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/LocalBoxLogonScript.ps1
@@ -37,43 +37,65 @@ foreach ($key in $keys) {
 
 #############################################################
 # Create desktop shortcut for Logs-folder
+# Wrapped in try-catch: fails gracefully when running as SYSTEM (no Desktop folder)
 #############################################################
 
-$WshShell = New-Object -comObject WScript.Shell
-$LogsPath = "C:\LocalBox\Logs"
-$Shortcut = $WshShell.CreateShortcut("$Env:USERPROFILE\Desktop\Logs.lnk")
-$Shortcut.TargetPath = $LogsPath
-$shortcut.WindowStyle = 3
-$shortcut.Save()
+try {
+    $desktopPath = "$Env:USERPROFILE\Desktop"
+    if (-not (Test-Path $desktopPath)) {
+        New-Item -ItemType Directory -Path $desktopPath -Force | Out-Null
+    }
+    $WshShell = New-Object -comObject WScript.Shell
+    $LogsPath = "C:\LocalBox\Logs"
+    $Shortcut = $WshShell.CreateShortcut("$desktopPath\Logs.lnk")
+    $Shortcut.TargetPath = $LogsPath
+    $shortcut.WindowStyle = 3
+    $shortcut.Save()
+} catch {
+    Write-Host "WARN: Could not create Logs shortcut (non-interactive session): $($_.Exception.Message)"
+}
 
 # Creating Hyper-V Manager desktop shortcut
-Write-Host 'Creating Hyper-V Shortcut'
-Copy-Item -Path 'C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Administrative Tools\Hyper-V Manager.lnk' -Destination 'C:\Users\All Users\Desktop' -Force
+try {
+    Write-Host 'Creating Hyper-V Shortcut'
+    Copy-Item -Path 'C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Administrative Tools\Hyper-V Manager.lnk' -Destination 'C:\Users\All Users\Desktop' -Force
+} catch {
+    Write-Host "WARN: Could not create Hyper-V shortcut: $($_.Exception.Message)"
+}
 
 #############################################################
 # Configure Windows Terminal as the default terminal application
 #############################################################
 
-$registryPath = "HKCU:\Console\%%Startup"
+try {
+    $registryPath = "HKCU:\Console\%%Startup"
 
-if (Test-Path $registryPath) {
-    Set-ItemProperty -Path $registryPath -Name "DelegationConsole" -Value "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}"
-    Set-ItemProperty -Path $registryPath -Name "DelegationTerminal" -Value "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}"
-} else {
-    New-Item -Path $registryPath -Force | Out-Null
-    Set-ItemProperty -Path $registryPath -Name "DelegationConsole" -Value "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}"
-    Set-ItemProperty -Path $registryPath -Name "DelegationTerminal" -Value "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}"
+    if (Test-Path $registryPath) {
+        Set-ItemProperty -Path $registryPath -Name "DelegationConsole" -Value "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}"
+        Set-ItemProperty -Path $registryPath -Name "DelegationTerminal" -Value "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}"
+    } else {
+        New-Item -Path $registryPath -Force | Out-Null
+        Set-ItemProperty -Path $registryPath -Name "DelegationConsole" -Value "{2EACA947-7F5F-4CFA-BA87-8F7FBEEFBE69}"
+        Set-ItemProperty -Path $registryPath -Name "DelegationTerminal" -Value "{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}"
+    }
+} catch {
+    Write-Host "WARN: Could not configure Windows Terminal defaults: $($_.Exception.Message)"
 }
 
 #############################################################
 # Install VSCode extensions
+# Skipped when running as SYSTEM (code.exe not in PATH)
 #############################################################
 
-Write-Host "[$(Get-Date -Format t)] INFO: Installing VSCode extensions: " + ($LocalBoxConfig.VSCodeExtensions -join ', ') -ForegroundColor Gray
-foreach ($extension in $LocalBoxConfig.VSCodeExtensions) {
-    $WarningPreference = "SilentlyContinue"
-    code --install-extension $extension 2>&1 | Out-File -Append -FilePath ($LocalBoxConfig.Paths.LogsDir + "\Tools.log")
-    $WarningPreference = "Continue"
+if (Get-Command code -ErrorAction SilentlyContinue) {
+    Write-Host "[$(Get-Date -Format t)] INFO: Installing VSCode extensions: " + ($LocalBoxConfig.VSCodeExtensions -join ', ') -ForegroundColor Gray
+    foreach ($extension in $LocalBoxConfig.VSCodeExtensions) {
+        $WarningPreference = "SilentlyContinue"
+        code --install-extension $extension 2>&1 | Out-File -Append -FilePath ($LocalBoxConfig.Paths.LogsDir + "\Tools.log")
+        $WarningPreference = "Continue"
+    }
+} else {
+    Write-Host "[$(Get-Date -Format t)] WARN: VSCode not found in PATH, skipping extension install (headless mode)"
 }
 
 #####################################################################

--- a/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
@@ -92,8 +92,50 @@ Set-VMHost -VirtualHardDiskPath $HostVMPath -VirtualMachinePath $HostVMPath -Ena
 Write-Host "Copying VHDX Files to Host virtualization drive"
 $guipath = "$HostVMPath\GUI.vhdx"
 $azlocalpath = "$HostVMPath\AzL-node.vhdx"
-Copy-Item -Path $LocalBoxConfig.guiVHDXPath -Destination $guipath -Force | Out-Null
-Copy-Item -Path $LocalBoxConfig.AzLocalVHDXPath -Destination $azlocalpath -Force | Out-Null
+
+# Copy with verification and retry (prevents silent failures that leave VMs without OS disks)
+$maxRetries = 3
+$vhdxCopies = @(
+    @{ Source = $LocalBoxConfig.guiVHDXPath;      Dest = $guipath;      Name = "GUI" },
+    @{ Source = $LocalBoxConfig.AzLocalVHDXPath;   Dest = $azlocalpath;  Name = "AzLocal" }
+)
+foreach ($copy in $vhdxCopies) {
+    if (-not (Test-Path $copy.Source)) {
+        Write-Error "$($copy.Name) source VHDX not found at $($copy.Source). Aborting."
+        throw "$($copy.Name) source VHDX not found at $($copy.Source)"
+    }
+    for ($attempt = 1; $attempt -le $maxRetries; $attempt++) {
+        Write-Host "  Copying $($copy.Name) VHDX (attempt $attempt/$maxRetries)..."
+        try {
+            Copy-Item -Path $copy.Source -Destination $copy.Dest -Force -ErrorAction Stop
+        } catch {
+            Write-Warning "  $($copy.Name) VHDX copy attempt $attempt failed: $($_.Exception.Message)"
+            if ($attempt -eq $maxRetries) {
+                Write-Error "$($copy.Name) VHDX copy failed after $maxRetries attempts. Source: $($copy.Source) Dest: $($copy.Dest)"
+                throw "$($copy.Name) VHDX copy failed after $maxRetries attempts"
+            }
+            Start-Sleep -Seconds 10
+            continue
+        }
+        if (Test-Path $copy.Dest) {
+            $srcSize = (Get-Item $copy.Source).Length
+            $dstSize = (Get-Item $copy.Dest -ErrorAction SilentlyContinue).Length
+            if ($srcSize -eq $dstSize) {
+                Write-Host "  $($copy.Name) VHDX copied successfully ($([math]::Round($dstSize/1GB,1)) GB)"
+                break
+            }
+            Write-Warning "  $($copy.Name) VHDX size mismatch (src=$srcSize dst=$dstSize), retrying..."
+            Remove-Item $copy.Dest -Force -ErrorAction SilentlyContinue
+        } else {
+            Write-Warning "  $($copy.Name) VHDX copy did not create destination file, retrying..."
+        }
+        if ($attempt -eq $maxRetries) {
+            Write-Error "$($copy.Name) VHDX copy failed after $maxRetries attempts. Source: $($copy.Source) Dest: $($copy.Dest)"
+            throw "$($copy.Name) VHDX copy failed after $maxRetries attempts"
+        }
+        Start-Sleep -Seconds 10
+    }
+}
 
 ################################################################################
 # Create the three nested Virtual Machines
@@ -116,7 +158,23 @@ Update-AzDeploymentProgressTag -ProgressString 'Creating Azure Local node VMs (A
 
 foreach ($VM in $LocalBoxConfig.NodeHostConfig) {
     $mac = New-AzLocalNodeVM -Name $VM.Hostname -VHDXPath $azlocalpath -VMSwitch $InternalSwitch -LocalBoxConfig $LocalBoxConfig
-    Set-AzLocalNodeVhdx -HostName $VM.Hostname -IPAddress $VM.IP -VMMac $mac  -LocalBoxConfig $LocalBoxConfig
+    if ([string]::IsNullOrWhiteSpace($mac)) {
+        Write-Error "New-AzLocalNodeVM returned null/empty MAC for $($VM.Hostname). Aborting."
+        throw "No MAC address returned for $($VM.Hostname)"
+    }
+    # Verify the node VM was created before proceeding
+    $nodeVm = Get-VM -Name $VM.Hostname -ErrorAction SilentlyContinue
+    if (-not $nodeVm) {
+        Write-Error "Hyper-V VM '$($VM.Hostname)' not found after New-AzLocalNodeVM. Aborting."
+        throw "Failed to create Hyper-V VM $($VM.Hostname)"
+    }
+    $vhdPath = ($nodeVm | Get-VMHardDiskDrive | Select-Object -First 1).Path
+    if (-not $vhdPath -or -not (Test-Path $vhdPath)) {
+        Write-Error "Node VM VHDX not found at $vhdPath after New-AzLocalNodeVM. Aborting."
+        throw "Failed to create VHDX for $($VM.Hostname)"
+    }
+    Write-Host "  $($VM.Hostname) VM created successfully (VHDX: $([math]::Round((Get-Item $vhdPath).Length/1GB,1)) GB)"
+    Set-AzLocalNodeVhdx -HostName $VM.Hostname -IPAddress $VM.IP -VMMac $mac -LocalBoxConfig $LocalBoxConfig
 }
 
 # Start Virtual Machines
@@ -190,6 +248,50 @@ Set-AzLocalDeployPrereqs -LocalBoxConfig $LocalBoxConfig -localCred $localCred -
 #######################################################################################
 
 Write-Host "[Build cluster - Step 10/11] Validate cluster deployment..." -ForegroundColor Green
+
+# Ensure mandatory resource providers are registered before HCI validation
+# This prevents the "ArcIntegration requirements not met" error (step 90)
+# when providers registered in Phase 1 haven't fully propagated
+Write-Host "Verifying mandatory resource provider registrations..." -ForegroundColor Yellow
+$mandatoryProviders = @(
+    "Microsoft.KubernetesConfiguration",
+    "Microsoft.ExtendedLocation",
+    "Microsoft.HybridContainerService",
+    "Microsoft.HybridCompute",
+    "Microsoft.AzureStackHCI",
+    "Microsoft.ResourceConnector",
+    "Microsoft.Kubernetes",
+    "Microsoft.EdgeMarketplace"
+)
+foreach ($rp in $mandatoryProviders) {
+    $rpState = (Get-AzResourceProvider -ProviderNamespace $rp -ErrorAction SilentlyContinue).RegistrationState | Select-Object -Unique
+    if ($rpState -ne 'Registered') {
+        Write-Host "  Registering $rp (current: $($rpState -join ', '))..." -ForegroundColor Yellow
+        Register-AzResourceProvider -ProviderNamespace $rp -ErrorAction SilentlyContinue | Out-Null
+    }
+}
+# Poll until all are Registered (max 5 minutes)
+$rpDeadline = (Get-Date).AddMinutes(5)
+$allRegistered = $false
+while (-not $allRegistered -and (Get-Date) -lt $rpDeadline) {
+    $allRegistered = $true
+    foreach ($rp in $mandatoryProviders) {
+        $rpState = (Get-AzResourceProvider -ProviderNamespace $rp -ErrorAction SilentlyContinue).RegistrationState | Select-Object -Unique
+        if ($rpState -ne 'Registered') {
+            $allRegistered = $false
+            Write-Host "  Waiting for $rp registration ($($rpState -join ', '))..." -ForegroundColor DarkGray
+            break
+        }
+    }
+    if (-not $allRegistered) {
+        Start-Sleep -Seconds 15
+    }
+}
+if ($allRegistered) {
+    Write-Host "All mandatory resource providers verified as Registered" -ForegroundColor Green
+} else {
+    Write-Warning "Some providers may not be fully registered — proceeding anyway (HCI validation will catch remaining issues)"
+}
 
 # Wait before starting validation to allow Connected Machines to register device information
 Start-Sleep -Seconds 600


### PR DESCRIPTION
## Summary

While preparing [LocalBox](https://github.com/microsoft/azure_arc/tree/main/azure_jumpstart_localbox) environments for [MicroHack](https://github.com/microsoft/MicroHack) workshops (50+ participants, 3+ subscriptions), we hit repeated deployment failures. Colleagues have also reported random cluster deployment failures independently. The root causes were hard to diagnose — scripts continued past errors silently, and failures only surfaced much later as cryptic downstream errors.

## Changes

### Fix 1 — VHDX copy verification with retry (`New-LocalBoxCluster.ps1`)

The VHDX copy path could fail silently, allowing VM creation to continue without valid OS disks and later fail at `Mount-VHD`. Replaced the copy flow with source pre-check, `try/catch` + `-ErrorAction Stop`, post-copy size validation, and up to 3 retries with 10-second backoff.

### Fix 2 — Node VM post-creation verification (`New-LocalBoxCluster.ps1`)

After `New-AzLocalNodeVM`, there was no validation that the Hyper-V VM and attached VHDX were actually present. Added explicit verification using `Get-VM` and `Get-VMHardDiskDrive`, plus null-check validation for the returned MAC address before continuing.

### Fix 3 — Missing scheduled task trigger (`Bootstrap.ps1`)

`LocalBoxLogonScript` was registered without a trigger, so it never fired in headless deployments. Added the missing logon trigger (`-AtLogOn`) to align behavior with the existing task registration pattern.

### Fix 4 — Resource provider registration polling (`New-LocalBoxCluster.ps1`)

`az provider register --wait` can return before registration fully propagates to HCI node context. Added explicit polling for 8 mandatory providers (15-second interval, 5-minute timeout) before the existing 600-second sleep, with non-blocking timeout fallback to preserve progress while improving reliability.

### Fix 5 — SYSTEM context handling (`LocalBoxLogonScript.ps1`)

When the `LocalBoxLogonScript` scheduled task runs as SYSTEM (via the AtLogOn trigger in headless CI), it crashes at line 47 because `$Env:USERPROFILE\Desktop` does not exist for the SYSTEM profile, and `code.exe` (VS Code) is not in the SYSTEM PATH. These are non-critical UI setup steps (desktop shortcuts, VS Code extensions) that should not abort the entire bootstrap. Wrapped all UI-related setup blocks in `try/catch` and added a `Get-Command code` guard for VSCode extension install.

## Files Modified

| File | Lines | Fixes |
|------|-------|-------|
| [`New-LocalBoxCluster.ps1`](https://github.com/microsoft/azure_arc/blob/main/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1) | +104 / -4 | Fixes 1, 2, 4 |
| [`Bootstrap.ps1`](https://github.com/microsoft/azure_arc/blob/main/azure_jumpstart_localbox/artifacts/PowerShell/Bootstrap.ps1) | +3 / -1 | Fix 3 |
| [`LocalBoxLogonScript.ps1`](https://github.com/microsoft/azure_arc/blob/main/azure_jumpstart_localbox/artifacts/PowerShell/LocalBoxLogonScript.ps1) | +43 / -21 | Fix 5 |

## Testing

- Syntax validation: all three files parse cleanly
- Tested on Windows Server 2022 VM (Standard_D4s_v5) with Hyper-V in Azure (Sweden Central)
- VHDX copy (fix 1): copy + size verification ✅, source-missing throw ✅, size-mismatch detection ✅
- VM verification (fix 2): VM + VHDX verify via `Get-VMHardDiskDrive` ✅, missing VM throw ✅, no-VHD throw ✅, MAC null-check ✅
- Task trigger (fix 3): trigger registration confirmed ✅, task not auto-started ✅
- RP polling (fix 4): `Select-Object -Unique` returns scalar ✅, registered/unregistered comparison ✅, no `System.Object[]` in logs ✅
- SYSTEM context (fix 5): Desktop folder creation fallback ✅, VSCode skip when not in PATH ✅, script continues past UI errors ✅

## Production Deployment Evidence

These fixes have been validated across 60+ GitHub Actions workflow runs deploying LocalBox to 3 Azure subscriptions simultaneously. The SYSTEM context fix (fix 5) was the final missing piece — without it, the scheduled task would crash before starting nested VMs in headless deployments.