### PR TITLE
Update LocalBox to use image version `AzLocal2604` instead of `AzLocal2601

### DIFF
--- a/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/New-LocalBoxCluster.ps1
@@ -31,8 +31,8 @@ Write-Output "Downloading nested VMs VHDX files. This can take some time, hold t
 #azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
 #azcopy cp 'https://jumpstartprodsg.blob.core.windows.net/jslocal/localbox/prod/AzLocal2509.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
 
-azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2601.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
-azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2601.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
+azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2604.vhdx' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx" --recursive=true --check-length=false --log-level=ERROR
+azcopy cp 'https://azlocalvhds.blob.core.windows.net/images/AzLocal2604.sha256' "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256" --recursive=true --check-length=false --log-level=ERROR
 
 $checksum = Get-FileHash -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.vhdx"
 $hash = Get-Content -Path "$($LocalBoxConfig.Paths.VHDDir)\AzL-node.sha256"

--- a/azure_jumpstart_localbox/artifacts/PowerShell/WinGet.ps1
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/WinGet.ps1
@@ -42,4 +42,40 @@ Get-ScheduledTask *LogonScript* | Start-ScheduledTask
 
 #Cleanup
 Unregister-ScheduledTask -TaskName 'WinGetLogonScript' -Confirm:$false
+
+# Temporary fix until LocalBox PowerShell module is updated
+# Define the file path
+$filePath = "C:\Program Files\WindowsPowerShell\Modules\Azure.Arc.Jumpstart.LocalBox\1.0.8\Azure.Arc.Jumpstart.LocalBox.psm1"
+
+# Check if the file exists
+if (Test-Path -Path $filePath) {
+    Write-Host "File found: $filePath" -ForegroundColor Green
+
+    # Read the file content
+    $content = Get-Content -Path $filePath -Raw
+
+    # Define the line to search for and the replacement
+    $searchString = '$ParentDiskPath = "C:\VMs\Base\AzL-node.vhdx"'
+    $replaceString = '$ParentDiskPath = "C:\VMs\Base\GUI.vhdx"'
+
+    # Check if the search string exists in the file
+    if ($content -match [regex]::Escape($searchString)) {
+        Write-Host "Found the line to replace." -ForegroundColor Yellow
+
+        # Replace the string
+        $newContent = $content -replace [regex]::Escape($searchString), $replaceString
+
+        # Write the updated content back to the file
+        Set-Content -Path $filePath -Value $newContent -NoNewline
+
+        Write-Host "Successfully replaced the line!" -ForegroundColor Green
+    }
+    else {
+        Write-Host "The specified line was not found in the file." -ForegroundColor Red
+    }
+}
+else {
+    Write-Host "File not found: $filePath" -ForegroundColor Yellow
+}
+
 Stop-Transcript


### PR DESCRIPTION
This pull request updates the VHDX image version used for nested VMs and introduces a temporary workaround in the `WinGet.ps1` script to address a configuration issue until the LocalBox PowerShell module is updated. The changes ensure that the correct VHDX image is used and automate a necessary configuration fix for users.

**VHDX Image Update:**

- Updated the VHDX and SHA256 download links in `New-LocalBoxCluster.ps1` to use version `AzLocal2604` instead of `AzLocal2601`, ensuring the latest image is used for nested VM provisioning.

**Temporary Workaround for Module Configuration:**

- Added a script section in `WinGet.ps1` that checks for the existence of the `Azure.Arc.Jumpstart.LocalBox.psm1` module file. If found, it replaces the line setting `$ParentDiskPath` to use `GUI.vhdx` instead of `AzL-node.vhdx`, providing a temporary fix until the module is officially updated.