### PR TITLE
Fix package ID for Azure Data Studio in YAML

### DIFF
--- a/azure_jumpstart_localbox/artifacts/PowerShell/dsc/packages.dsc.yml
+++ b/azure_jumpstart_localbox/artifacts/PowerShell/dsc/packages.dsc.yml
@@ -66,10 +66,10 @@ properties:
         id: Microsoft.SQLServerManagementStudio
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
-      id: Microsoft.AzureDataStudio
+      id: Microsoft.Azure.DataStudio
       directives:
         description: Install Microsoft Azure Data Studio
       settings:
-        id: Microsoft.AzureDataStudio
+        id: Microsoft.Azure.DataStudio
         source: winget    
   configurationVersion: 0.2.0


### PR DESCRIPTION
Azure Data Studio winget package ID incorrect. Updated to proper reference ID `Microsoft.Azure.DataStudio`